### PR TITLE
Allow more variables to be passed to ctest.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -169,6 +169,12 @@ foreach( lang C CXX Fortran )
   if( CMAKE_${lang}_COMPILER )
     list( APPEND _test_args "-DCMAKE_${lang}_COMPILER=${CMAKE_${lang}_COMPILER}" )
   endif()
+  if( CMAKE_${lang}_FLAGS )
+    list( APPEND _test_args "-DCMAKE_${lang}_FLAGS=${CMAKE_${lang}_FLAGS}" )
+  endif()
+  if( CMAKE_EXE_LINKER_FLAGS )
+    list( APPEND _test_args "-DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}" )
+  endif()
 endforeach()
 
 add_test( NAME fiat_test_install


### PR DESCRIPTION
It is currently difficult to get some ctests to work as they rely on being able to compile executables and for some platforms the compilation requires things like Fortran compiler options to be set when doing so.  This allows some extra options to be passed via the ctest command to the compilation of ctest executables.