### PR TITLE
Only add fckit definitions if `HAVE_FCKIT` is true

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,10 @@ ecbuild_add_option( FEATURE MPI
                     DESCRIPTION "Support for MPI distributed parallelism"
                     REQUIRED_PACKAGES "MPI COMPONENTS Fortran" )
 
+ecbuild_find_package( fckit QUIET )
 ecbuild_add_option( FEATURE FCKIT
                     DESCRIPTION "Support for fckit"
-                    REQUIRED_PACKAGES "fckit QUIET" )
+                    CONDITION fckit_FOUND AND fckit_HAVE_ECKIT )
 
 ecbuild_add_option( FEATURE DR_HOOK_MULTI_PRECISION_HANDLES
                     DESCRIPTION "[DEPRECATED] Support single precision handles for DR_HOOK"

--- a/src/fiat/CMakeLists.txt
+++ b/src/fiat/CMakeLists.txt
@@ -74,7 +74,7 @@ endif()
 
 target_compile_definitions( fiat PRIVATE ${FIAT_DEFINITIONS} )
 
-if( TARGET fckit )
+if( HAVE_FCKIT )
     target_link_libraries( fiat PRIVATE fckit )
 endif()
 

--- a/src/fiat/CMakeLists.txt
+++ b/src/fiat/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 ### Assemble list of definitions
 
-if( TARGET fckit )
+if( HAVE_FCKIT )
   list( APPEND FIAT_DEFINITIONS WITH_FCKIT )
 endif()
 


### PR DESCRIPTION
A small fix that allows fckit linking to be disabled even if libfckit is defined as a target (e.g. in a bundle build).