### PR TITLE
Add NVTX support via DrHook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,21 @@ ecbuild_add_option( FEATURE WARNINGS
 
 ecbuild_find_package( NAME Realtime QUIET )
 
+#### 
+
+if(CMAKE_C_COMPILER_ID STREQUAL "PGI" OR CMAKE_C_COMPILER_ID STREQUAL "NVHPC" )
+
+ find_package(CUDAToolkit REQUIRED COMPONENTS nvtx3)
+ find_package(NVHPC REQUIRED COMPONENTS HOSTUTILS)
+   
+ find_library(NVTOOLSEXT_LIB NAMES nvToolsExt  REQUIRED HINTS ${CUDAToolkit_LIBRARY_DIR})
+ find_library(NVHPCWRAPNVTX_LIB NAMES nvhpcwrapnvtx  REQUIRED HINTS  ${NVHPC_HOSTUTILS_LIBRARY_DIR} )
+
+endif()
+ 
+
+
+
 ### Sources
 
 include( fiat_compiler_warnings )

--- a/cmake/project_summary.cmake
+++ b/cmake/project_summary.cmake
@@ -23,5 +23,11 @@ ecbuild_info( "MPI (export MPI_HOME to correct MPI implementation)" )
 ecbuild_info( "    MPI_Fortran_INCLUDE_DIRS  : [${MPI_Fortran_INCLUDE_DIRS}]" )
 ecbuild_info( "    MPI_Fortran_LIBRARIES     : [${MPI_Fortran_LIBRARIES}]" )
 ecbuild_info( "    MPIEXEC                   : [${MPIEXEC}]" )
+
+if(CMAKE_C_COMPILER_ID STREQUAL "PGI" OR CMAKE_C_COMPILER_ID STREQUAL "NVHPC" )
+ecbuild_info( " nvToolsExt library from CUDAToolkit : [${NVTOOLSEXT_LIB}]" )
+ecbuild_info( " nvhpcwrapnvtx library from NVHPC : [${NVHPCWRAPNVTX_LIB}]" ) 
+endif()
+
 ecbuild_info( "---------------------------------------------------------" )
 

--- a/src/fiat/CMakeLists.txt
+++ b/src/fiat/CMakeLists.txt
@@ -44,6 +44,12 @@ endif()
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/library/version.c.in ${CMAKE_CURRENT_BINARY_DIR}/version.c @ONLY )
 
 ecbuild_list_add_pattern( LIST fiat_src GLOB *.c *.F* *.cc )
+if(NOT (CMAKE_C_COMPILER_ID STREQUAL "PGI" OR CMAKE_C_COMPILER_ID STREQUAL "NVHPC" ))
+	# The files in the mynvtx directory are only intended to work with NVHPC
+	#	So don't try to compile them when using another compiler
+	ecbuild_list_exclude_pattern( LIST fiat_src REGEX mynvtx/* )
+endif()
+
 set( fiat_src ${fiat_src} PARENT_SCOPE )
 
 ecbuild_add_library( TARGET fiat
@@ -65,6 +71,14 @@ ecbuild_add_library( TARGET fiat
         $<INSTALL_INTERFACE:include/fiat>
 )
 
+
+## if compiler is pgi  add two libs 
+
+if(CMAKE_C_COMPILER_ID STREQUAL "PGI" OR CMAKE_C_COMPILER_ID STREQUAL "NVHPC" )
+   target_link_libraries(fiat PUBLIC ${NVTOOLSEXT_LIB})
+   target_link_libraries(fiat PUBLIC ${NVHPCWRAPNVTX_LIB})
+   target_include_directories(fiat PRIVATE "${CUDAToolkit_LIBRARY_DIR}/../include")
+endif()
 
 if( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
   # Following should not be necessary; 

--- a/src/fiat/drhook/internal/dr_hook_util.F90
+++ b/src/fiat/drhook/internal/dr_hook_util.F90
@@ -13,6 +13,10 @@ USE EC_PARKIND , ONLY : JPIM, JPRD
 USE OML_MOD    , ONLY : OML_MY_THREAD
 USE YOMHOOK    , ONLY : LHOOK
 USE DR_HACK_MOD, ONLY : LL_DRHACK, DR_HACK_INIT, DR_HACK
+#ifdef __PGI
+USE NVTX
+USE MYNVTX
+#endif
 
 IMPLICIT NONE
 
@@ -32,6 +36,31 @@ INTEGER(KIND=JPIM) :: IMYTID
 INTEGER(KIND=8)    :: MAXMEM=0 ! For comparing memory between HEAPCHECK_START and HEAPCHECK_END
 
 #include "dr_hook_init.intfb.h"
+
+#ifdef __PGI
+INTEGER, SAVE :: II_DRNVTX = 0 ! 0=no initialized, -1=nvtx off, +1=nvtx on
+CHARACTER*32 :: CL_NVTX
+#endif
+
+
+#ifdef __PGI
+IF (II_DRNVTX == 0) THEN
+  CALL GETENV ('DR_NVTX', CL_NVTX)
+  IF (CL_NVTX == '1') THEN
+    II_DRNVTX = +1
+  ELSE
+    II_DRNVTX = -1
+  ENDIF
+ENDIF
+
+IF (II_DRNVTX == 1) THEN
+  IF (KCASE == 0) THEN
+      CALL PUSH_RANGE(CDNAME)
+  ELSEIF (KCASE==1) THEN
+      CALL POP_RANGE(CDNAME)
+  ENDIF
+ENDIF
+#endif
 
 IF (.NOT.LDHOOK) RETURN
 

--- a/src/fiat/mynvtx/map.cc
+++ b/src/fiat/mynvtx/map.cc
@@ -1,0 +1,75 @@
+#include <unordered_map>
+#include <cstring>
+#include <iostream>
+using namespace std;
+
+extern "C" double MPI_Wtime ();
+#pragma weak MPI_Wtime
+
+//extern int map_start(const char * str);
+//extern void map_stop();
+
+struct mystruct {
+
+   int calls = 0;
+   double elapsed = 0;
+   double t0 = 0;
+
+};
+
+template <class _Tp>
+struct my_equal_to : public binary_function<_Tp, _Tp, bool>
+{
+    bool operator()(const _Tp& __x, const _Tp& __y) const
+    { return strcmp( __x, __y ) == 0; }
+};
+
+
+struct Hash_Func{
+    //BKDR hash algorithm
+    int operator()(const char * str)const
+    {
+        int seed = 131;//31  131 1313 13131131313 etc//
+        int hash = 0;
+        while(*str)
+        {
+            hash = (hash * seed) + (*str);
+            str ++;
+        }
+
+        return hash & (0x7FFFFFFF);
+    }
+};
+
+struct mystruct * stack[128];
+
+std::unordered_map<char const*, struct mystruct, Hash_Func,  my_equal_to<const char*>> map;
+static int ilast = 0;
+extern "C"
+int map_start(const char * str) {
+
+   struct mystruct * elem = &(map[str]);
+   ilast++;
+   stack[ilast] = elem;
+   elem->calls ++;
+   if (elem->calls >= 11 && elem->elapsed < 0.0001) {
+      return 0;
+   }
+   if (elem->calls > 1)
+          elem->t0 = MPI_Wtime();
+   return 1;
+}
+
+extern "C"
+int map_stop() {
+
+   struct mystruct * last = stack[ilast];
+   ilast--;
+   if (last->calls >= 11 && last->elapsed < 0.0001) {
+      return 0;
+   }
+   if (last->calls > 1)
+          last->elapsed += MPI_Wtime() - last->t0;
+   return 1;
+}
+

--- a/src/fiat/mynvtx/nvtx.F90
+++ b/src/fiat/mynvtx/nvtx.F90
@@ -1,0 +1,54 @@
+
+!!mpif90 nvtx.f90 -Mpreprocess -c -O2
+
+#ifndef NVTX_PROFILE
+#define NVTX_PROFILE 1
+#endif
+
+module mynvtx
+   use iso_c_binding
+   implicit none
+     interface
+        subroutine mynvtxstart(name)
+           use iso_c_binding
+           character(kind=c_char,len=*) :: name
+        end subroutine
+        subroutine nvtxRangePop() bind(c,name="nvtxRangePop")
+        end subroutine
+     end interface
+     PUBLIC :: PUSH_RANGE
+     PUBLIC :: POP_RANGE
+     contains
+  subroutine PUSH_RANGE(fstr)
+    character(kind=c_char,len=*), intent(in) :: fstr
+#if NVTX_PROFILE != 0
+    character(kind=c_char,len=1024) :: cstr
+    !$omp master
+
+    cstr=trim(fstr)//c_null_char
+
+    call mynvtxstart(cstr)
+    !$omp end master
+#endif
+  end subroutine PUSH_RANGE
+
+  subroutine POP_RANGE(fstr)
+    character(kind=c_char,len=*), intent(in) :: fstr
+#ifdef NVTX_VERYVERBOSE
+    character(kind=c_char,len=1024) :: cstr
+#endif
+    !$omp master
+#if NVTX_PROFILE != 0
+#ifdef NVTX_VERYVERBOSE
+    cstr=trim(fstr)//c_null_char
+    call mynvtxend(cstr)
+#else
+    call mynvtxend()
+#endif
+
+!!    call nvtxRangePop
+#endif
+!$omp end master
+  end subroutine POP_RANGE
+end module mynvtx
+

--- a/src/fiat/mynvtx/nvtx.c
+++ b/src/fiat/mynvtx/nvtx.c
@@ -1,0 +1,90 @@
+#include <nvToolsExt.h>
+#include <string.h>
+
+// mpicc -c nvtx.c -O2
+
+   uint32_t myadler32(const unsigned char *data)
+   {
+      const uint32_t MOD_ADLER = 65521;
+      uint32_t a = 1, b = 0;
+      size_t index;
+      for (index = 0; data[index] != 0; ++index)
+      {
+         a = (a + data[index]*2) % MOD_ADLER;
+         b = (b + a) % MOD_ADLER;
+      }
+      return (b << 16) | a;
+   }
+   extern int map_start(const char * str);
+#ifdef NVTX_VERYVERBOSE
+   const char namestack[256][256];
+   int istack=0;
+#endif
+//   int first = 1;
+void mynvtxstart_(const char *name) {
+   if (!map_start(name)) {
+#ifdef NVTX_VERYVERBOSE
+      for(int i=0;i<istack;i++) printf(" ");
+      printf("Skipped open --- %s\n",name);
+#endif
+      return;
+   }
+
+   int hash = 0;
+   int color_id = myadler32((const unsigned char*)name);
+   int r,g,b;
+   r=color_id & 0x000000ff;
+   g=(color_id & 0x000ff000) >> 12;
+   b=(color_id & 0x0ff00000) >> 20;
+   if (r<64 & g<64 & b<64) {
+      r=r*3;
+      g=g*3+64;
+      b=b*4;
+   }
+
+   color_id = 0xff000000 | (r << 16) | (g << 8) | (b);
+   nvtxEventAttributes_t eventAttrib = {0};
+   eventAttrib.version = NVTX_VERSION;
+   eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+   eventAttrib.colorType = NVTX_COLOR_ARGB;
+   eventAttrib.color = color_id;
+   eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+   eventAttrib.message.ascii = name;
+#ifdef NVTX_VERYVERBOSE
+   for(int i=0;i<istack;i++) printf(" ");
+   printf("Opening %s\n",name);
+#endif
+   nvtxRangePushEx(&eventAttrib);
+#ifdef NVTX_VERYVERBOSE
+   strncpy(namestack[istack], name, 128);
+   istack++;
+#endif
+
+}
+#ifdef NVTX_VERYVERBOSE
+void mynvtxend_(const char *name) {
+#else
+void mynvtxend_() {
+#endif
+   if (!map_stop()){
+#ifdef NVTX_VERYVERBOSE
+      for(int i=0;i<istack-1;i++) printf(" ");
+      printf("Skipped end --- %s\n",name);
+#endif
+      return;
+   }
+#ifdef NVTX_VERYVERBOSE
+   istack--;
+   if (istack < 0) {
+      printf("NVTX error negative stack\n");
+      exit(-1);
+   }
+   for(int i=0;i<istack;i++) printf(" ");
+   printf("Closing %s\n",name);
+   if (strcmp(name,namestack[istack])) {
+      printf("Error just closed the wrong marker: %s expected: %s\n",name, namestack[istack]);
+      abort(1);
+   }
+#endif
+   nvtxRangePop();
+}

--- a/src/fiat/mynvtx/nvtx.h
+++ b/src/fiat/mynvtx/nvtx.h
@@ -1,0 +1,10 @@
+#ifdef __cplusplus
+extern "C"
+#endif
+void mynvtxstart_(const char *name);
+#ifdef __cplusplus
+extern "C"
+#endif
+void nvtxRangePop();
+#define PUSH_RANGE(name) { mynvtxstart_(name);}
+#define POP_RANGE(name) nvtxRangePop();


### PR DESCRIPTION
This PR enables NVTX instrumentation using DrHook (PGI only). This is enabled with the two following environment variables :
- DR_HOOK=1
- DR_NVTX = 1

Example of an ARPEGE nsys profile with NVTX enabled : 
![nvtx-color](https://github.com/ecmwf-ifs/fiat/assets/5940005/b684a5e8-4899-41f5-a3d5-c82e9b1586ba)
