### PR TITLE
Fixup linking with NVTX across various CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,11 @@ ecbuild_add_option( FEATURE WARNINGS
                     DEFAULT ON
                     DESCRIPTION "Add warnings to compiler" )
 
-
+if(CMAKE_C_COMPILER_ID STREQUAL "PGI" OR CMAKE_C_COMPILER_ID STREQUAL "NVHPC" )
+    set (DEFAULT_DR_HOOK_NVTX ON)
+else()
+    set (DEFAULT_DR_HOOK_NVTX OFF)
+endif()
 ecbuild_add_option( FEATURE DR_HOOK_NVTX
                     DEFAULT ${DEFAULT_DR_HOOK_NVTX}
                     DESCRIPTION "Support for NVTX in DR_HOOK"

--- a/src/fiat/CMakeLists.txt
+++ b/src/fiat/CMakeLists.txt
@@ -74,13 +74,11 @@ if (HAVE_DR_HOOK_NVTX)
     ecbuild_list_add_pattern( LIST fiat_nvtx_src GLOB *.c SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/drhook/extensions/nvtx)
     target_sources(fiat PRIVATE ${fiat_nvtx_src})
     target_include_directories(fiat PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/drhook/extensions/nvtx)
+    target_compile_definitions(fiat PRIVATE DR_HOOK_HAVE_NVTX=1 HAVE_NVTX3=${HAVE_NVTX3} )
 
-    # Files defined externally
-    target_include_directories( fiat PRIVATE ${NVTX_INCLUDE_DIRS} )
-    target_compile_definitions( fiat PRIVATE DR_HOOK_HAVE_NVTX=1 )
-    if( CMAKE_VERSION VERSION_LESS 3.25 )
-        target_link_libraries     ( fiat PRIVATE ${NVTX_LIBRARIES} )
-    endif()
+    # Link with NVTX
+    target_link_libraries     (fiat PRIVATE ${NVTX_LIBRARIES})
+    target_include_directories(fiat PRIVATE ${NVTX_INCLUDE_DIRS})
 endif()
 
 if( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )

--- a/src/fiat/drhook/extensions/nvtx/dr_hook_nvtx.c
+++ b/src/fiat/drhook/extensions/nvtx/dr_hook_nvtx.c
@@ -9,7 +9,11 @@
  * nor does it submit to any jurisdiction.
  */
 
+#if HAVE_NVTX3
+#include <nvtx3/nvToolsExt.h>
+#else
 #include <nvToolsExt.h>
+#endif
 #include <string.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
With CMake < 3.20 there is no CUDAToolkit.
With CMake < 3.25 there is no CUDA::nvtx3 component in CUDAToolkit which provides header-only implementation.
Finally there were linking issues where the header-only implementation was using the non-header-only older include dirs.
