### PR TITLE
Enable NAG to see the unlink function

### DIFF
--- a/tests/test_namelist.F90
+++ b/tests/test_namelist.F90
@@ -16,6 +16,9 @@
 
 program test_namelist
 use namelist_mod
+#ifdef NAGFOR
+use f90_unix_dir, only: unlink
+#endif
 implicit none
 
 character(len=*),parameter :: cfile = 'fort.4'


### PR DESCRIPTION
Addresses #46 by enabling NAG to use the unlink function via its intrinsic module.