### PR TITLE
Add fletcher16 checksum algorithm in new ec_checksum_mod

### DIFF
--- a/src/fiat/include/fiat/ec_checksum.h
+++ b/src/fiat/include/fiat/ec_checksum.h
@@ -1,0 +1,22 @@
+#ifndef EC_CHECKSUM_H
+#define EC_CHECKSUM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef int32_t ec_checksum_fletcher16_t;
+
+uint16_t ec_checksum_fletcher16(const void* data, size_t bytes);
+void ec_checksum_fletcher16_reset(ec_checksum_fletcher16_t*);
+void ec_checksum_fletcher16_update(ec_checksum_fletcher16_t*, const void* data, size_t bytes);
+uint16_t ec_checksum_fletcher16_digest(const ec_checksum_fletcher16_t*);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif

--- a/src/fiat/util/ec_checksum.F90
+++ b/src/fiat/util/ec_checksum.F90
@@ -1,0 +1,761 @@
+! (C) Copyright 2025- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+!
+
+module ec_checksum_mod
+
+!**** Checksum of arrays
+!
+!     Purpose.
+!     --------
+!     Take the checksum of an array printed as 4-char string
+!
+!     An example Fortran programs:
+!
+!         program main
+!             use ec_checksum_mod, only: fletcher16, fletcher16_hex
+!             write(0,*) fletcher16(array(:,:))     ! as integer
+!             write(0,*) fletcher16_hex(array(:,:)) ! as hex-string
+!         end program
+!
+!     Multiple arrays can be checksummed together to a single hash:
+!
+!         program main
+!             use ec_checksum_mod, only: fletcher16_type
+!             type(fletcher16_type) :: checksum
+!             call checksum%update(array1(:,:))
+!             call checksum%update(array2(:,:,:))
+!             write(0,*) checksum%digest_hex()
+!         end program
+!
+!     Author.
+!     -------
+!        W.Deconinck, ECMWF
+!
+!     Modifications.
+!     --------------
+!        Original: 2025-07-04
+!
+!     ------------------------------------------------------------------
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int32_t, c_int16_t, c_char
+  implicit none
+
+private
+public :: fletcher16_type, fletcher16, fletcher16_hex
+
+type :: fletcher16_type
+  integer(c_int32_t) :: handle = 0
+contains
+  procedure, public  :: reset => fletcher16_reset
+  procedure, private :: update_real32_r1 => fletcher16_update_real32_r1
+  procedure, private :: update_real32_r2 => fletcher16_update_real32_r2
+  procedure, private :: update_real32_r3 => fletcher16_update_real32_r3
+  procedure, private :: update_real32_r4 => fletcher16_update_real32_r4
+  procedure, private :: update_real32_r5 => fletcher16_update_real32_r5
+  procedure, private :: update_real64_r1 => fletcher16_update_real64_r1
+  procedure, private :: update_real64_r2 => fletcher16_update_real64_r2
+  procedure, private :: update_real64_r3 => fletcher16_update_real64_r3
+  procedure, private :: update_real64_r4 => fletcher16_update_real64_r4
+  procedure, private :: update_real64_r5 => fletcher16_update_real64_r5
+  procedure, private :: update_int32_r1  => fletcher16_update_int32_r1
+  procedure, private :: update_int32_r2  => fletcher16_update_int32_r2
+  procedure, private :: update_int32_r3  => fletcher16_update_int32_r3
+  procedure, private :: update_int32_r4  => fletcher16_update_int32_r4
+  procedure, private :: update_int32_r5  => fletcher16_update_int32_r5
+  procedure, private :: update_int64_r1  => fletcher16_update_int64_r1
+  procedure, private :: update_int64_r2  => fletcher16_update_int64_r2
+  procedure, private :: update_int64_r3  => fletcher16_update_int64_r3
+  procedure, private :: update_int64_r4  => fletcher16_update_int64_r4
+  procedure, private :: update_int64_r5  => fletcher16_update_int64_r5
+  generic, public :: update => &
+    & update_real32_r1, update_real32_r2, update_real32_r3, update_real32_r4, update_real32_r5, &
+    & update_real64_r1, update_real64_r2, update_real64_r3, update_real64_r4, update_real64_r5, &
+    & update_int32_r1,  update_int32_r2,  update_int32_r3,  update_int32_r4,  update_int32_r5,  &
+    & update_int64_r1,  update_int64_r2,  update_int64_r3,  update_int64_r4,  update_int64_r5
+
+  procedure, public :: digest     => fletcher16__digest
+  procedure, public :: digest_hex => fletcher16__digest_hex
+end type
+
+interface
+    subroutine c_fletcher16_reset(checksum) bind(C,name="ec_checksum_fletcher16_reset")
+      use, intrinsic :: iso_c_binding, only : c_int32_t
+      integer(c_int32_t), intent(inout) :: checksum
+    end subroutine
+
+    subroutine c_ec_checksum_fletcher16_update(checksum, data, size) bind(C,name="ec_checksum_fletcher16_update")
+      use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int32_t
+      integer(c_int32_t), intent(inout) :: checksum
+      type(c_ptr), value, intent(in) :: data
+      integer(c_size_t), value, intent(in) :: size
+    end subroutine
+
+    function c_ec_checksum_fletcher16_digest(checksum) bind(C,name="ec_checksum_fletcher16_digest") result(digest)
+      use, intrinsic :: iso_c_binding, only : c_int32_t, c_int16_t
+      integer(c_int16_t) :: digest
+      integer(c_int32_t), intent(in) :: checksum
+    end function
+end interface
+
+interface fletcher16
+module procedure fletcher16_real32_r1
+module procedure fletcher16_real32_r2
+module procedure fletcher16_real32_r3
+module procedure fletcher16_real32_r4
+module procedure fletcher16_real32_r5
+module procedure fletcher16_real64_r1
+module procedure fletcher16_real64_r2
+module procedure fletcher16_real64_r3
+module procedure fletcher16_real64_r4
+module procedure fletcher16_real64_r5
+module procedure fletcher16_int32_r1
+module procedure fletcher16_int32_r2
+module procedure fletcher16_int32_r3
+module procedure fletcher16_int32_r4
+module procedure fletcher16_int32_r5
+module procedure fletcher16_int64_r1
+module procedure fletcher16_int64_r2
+module procedure fletcher16_int64_r3
+module procedure fletcher16_int64_r4
+module procedure fletcher16_int64_r5
+end interface
+
+interface fletcher16_hex
+module procedure fletcher16_hex_real32_r1
+module procedure fletcher16_hex_real32_r2
+module procedure fletcher16_hex_real32_r3
+module procedure fletcher16_hex_real32_r4
+module procedure fletcher16_hex_real32_r5
+module procedure fletcher16_hex_real64_r1
+module procedure fletcher16_hex_real64_r2
+module procedure fletcher16_hex_real64_r3
+module procedure fletcher16_hex_real64_r4
+module procedure fletcher16_hex_real64_r5
+module procedure fletcher16_hex_int32_r1
+module procedure fletcher16_hex_int32_r2
+module procedure fletcher16_hex_int32_r3
+module procedure fletcher16_hex_int32_r4
+module procedure fletcher16_hex_int32_r5
+module procedure fletcher16_hex_int64_r1
+module procedure fletcher16_hex_int64_r2
+module procedure fletcher16_hex_int64_r3
+module procedure fletcher16_hex_int64_r4
+module procedure fletcher16_hex_int64_r5
+end interface
+
+interface to_hex
+module procedure to_hex_16
+module procedure to_hex_32
+module procedure to_hex_64
+end interface
+
+contains
+
+subroutine to_lower_inplace(string)
+  character(len=*), intent(inout) :: string
+  integer :: i
+  do i = 1, len(string)
+    string(i:i) = char_to_lower(string(i:i))
+  end do
+contains
+  pure function char_to_lower(c) result(t)
+    character(len=1), intent(in) :: c !! A character.
+    character(len=1)             :: t
+    integer, parameter :: wp= iachar('a')-iachar('A'), BA=iachar('A'), BZ=iachar('Z')
+    integer :: k
+    ! Check whether the integer equivalent is between BA=65 and BZ=90
+    k = ichar(c)
+    if (k>=BA.and.k<=BZ) k = k + wp
+    t = char(k)
+  end function
+end subroutine
+
+function to_hex_16(value) result(hex)
+  use, intrinsic :: iso_c_binding, only : c_int16_t
+  character(len=4) :: hex
+  integer(c_int16_t), intent(in) :: value
+  write(hex,'(z4.4)') value
+  call to_lower_inplace(hex)
+end function
+
+function to_hex_32(value) result(hex)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  character(len=8) :: hex
+  integer(c_int32_t), intent(in) :: value
+  write(hex,'(z8.8)') value
+  call to_lower_inplace(hex)
+end function
+
+function to_hex_64(value) result(hex)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  character(len=16) :: hex
+  integer(c_int64_t), intent(in) :: value
+  write(hex,'(z16.16)') value
+  call to_lower_inplace(hex)
+end function
+
+subroutine fletcher16_reset(this)
+  class(fletcher16_type), intent(inout) :: this
+  this%handle = 0
+end subroutine
+
+subroutine fletcher16_update_real32_r1(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_float
+  class(fletcher16_type), intent(inout) :: this
+  real(c_float), contiguous, target, intent(in) :: array(:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1)), c_sizeof(array(1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_real32_r2(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_float
+  class(fletcher16_type), intent(inout) :: this
+  real(c_float), contiguous, target, intent(in) :: array(:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1)), c_sizeof(array(1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_real32_r3(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_float
+  class(fletcher16_type), intent(inout) :: this
+  real(c_float), contiguous, target, intent(in) :: array(:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1)), c_sizeof(array(1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_real32_r4(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_float
+  class(fletcher16_type), intent(inout) :: this
+  real(c_float), contiguous, target, intent(in) :: array(:,:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1,1)), c_sizeof(array(1,1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_real32_r5(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_float
+  class(fletcher16_type), intent(inout) :: this
+  real(c_float), contiguous, target, intent(in) :: array(:,:,:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1,1,1)), c_sizeof(array(1,1,1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_real64_r1(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_double
+  class(fletcher16_type), intent(inout) :: this
+  real(c_double), contiguous, target, intent(in) :: array(:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1)), c_sizeof(array(1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_real64_r2(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_double
+  class(fletcher16_type), intent(inout) :: this
+  real(c_double), contiguous, target, intent(in) :: array(:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1)), c_sizeof(array(1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_real64_r3(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_double
+  class(fletcher16_type), intent(inout) :: this
+  real(c_double), contiguous, target, intent(in) :: array(:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1)), c_sizeof(array(1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_real64_r4(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_double
+  class(fletcher16_type), intent(inout) :: this
+  real(c_double), contiguous, target, intent(in) :: array(:,:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1,1)), c_sizeof(array(1,1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_real64_r5(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_double
+  class(fletcher16_type), intent(inout) :: this
+  real(c_double), contiguous, target, intent(in) :: array(:,:,:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1,1,1)), c_sizeof(array(1,1,1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_int32_r1(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_int32_t
+  class(fletcher16_type), intent(inout) :: this
+  integer(c_int32_t), contiguous, target, intent(in) :: array(:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1)), c_sizeof(array(1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_int32_r2(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_int32_t
+  class(fletcher16_type), intent(inout) :: this
+  integer(c_int32_t), contiguous, target, intent(in) :: array(:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1)), c_sizeof(array(1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_int32_r3(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_int32_t
+  class(fletcher16_type), intent(inout) :: this
+  integer(c_int32_t), contiguous, target, intent(in) :: array(:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1)), c_sizeof(array(1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_int32_r4(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_int32_t
+  class(fletcher16_type), intent(inout) :: this
+  integer(c_int32_t), contiguous, target, intent(in) :: array(:,:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1,1)), c_sizeof(array(1,1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_int32_r5(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof, c_int32_t
+  class(fletcher16_type), intent(inout) :: this
+  integer(c_int32_t), contiguous, target, intent(in) :: array(:,:,:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1,1,1)), c_sizeof(array(1,1,1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_int64_r1(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof
+  class(fletcher16_type), intent(inout) :: this
+  integer(c_int64_t), contiguous, target, intent(in) :: array(:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1)), c_sizeof(array(1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_int64_r2(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof
+  class(fletcher16_type), intent(inout) :: this
+  integer(c_int64_t), contiguous, target, intent(in) :: array(:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1)), c_sizeof(array(1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_int64_r3(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof
+  class(fletcher16_type), intent(inout) :: this
+  integer(c_int64_t), contiguous, target, intent(in) :: array(:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1)), c_sizeof(array(1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_int64_r4(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof
+  class(fletcher16_type), intent(inout) :: this
+  integer(c_int64_t), contiguous, target, intent(in) :: array(:,:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1,1)), c_sizeof(array(1,1,1,1)) * array_size)
+  endif
+end subroutine
+
+subroutine fletcher16_update_int64_r5(this, array)
+  use, intrinsic :: iso_c_binding, only : c_ptr, c_size_t, c_int64_t, c_loc, c_sizeof
+  class(fletcher16_type), intent(inout) :: this
+  integer(c_int64_t), contiguous, target, intent(in) :: array(:,:,:,:,:)
+  integer(c_size_t) :: array_size
+  array_size = size(array,kind=c_size_t)
+  if (array_size > 0) then
+    call c_ec_checksum_fletcher16_update(this%handle, c_loc(array(1,1,1,1,1)), c_sizeof(array(1,1,1,1,1)) * array_size)
+  endif
+end subroutine
+
+function fletcher16__digest(this) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int16_t
+  class(fletcher16_type), intent(in) :: this
+  integer(c_int16_t) :: digest
+  digest = c_ec_checksum_fletcher16_digest(this%handle)
+end function
+
+function fletcher16__digest_hex(this) result(digest)
+  class(fletcher16_type), intent(in) :: this
+  character(len=4) :: digest
+  digest = to_hex(this%digest())
+end function
+
+
+function fletcher16_real32_r1(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_float
+  integer(c_int16_t) :: digest
+  real(c_float), intent(in) :: array(:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_real32_r2(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_float
+  integer(c_int16_t) :: digest
+  real(c_float), intent(in) :: array(:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_real32_r3(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_float
+  integer(c_int16_t) :: digest
+  real(c_float), intent(in) :: array(:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_real32_r4(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_float
+  integer(c_int16_t) :: digest
+  real(c_float), intent(in) :: array(:,:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_real32_r5(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_float
+  integer(c_int16_t) :: digest
+  real(c_float), intent(in) :: array(:,:,:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_real64_r1(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_double
+  integer(c_int16_t) :: digest
+  real(c_double), intent(in) :: array(:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_real64_r2(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_double
+  integer(c_int16_t) :: digest
+  real(c_double), intent(in) :: array(:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_real64_r3(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_double
+  integer(c_int16_t) :: digest
+  real(c_double), intent(in) :: array(:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_real64_r4(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_double
+  integer(c_int16_t) :: digest
+  real(c_double), intent(in) :: array(:,:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_real64_r5(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_double
+  integer(c_int16_t) :: digest
+  real(c_double), intent(in) :: array(:,:,:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_int32_r1(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  integer(c_int16_t) :: digest
+  integer(c_int32_t), intent(in) :: array(:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_int32_r2(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  integer(c_int16_t) :: digest
+  integer(c_int32_t), intent(in) :: array(:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_int32_r3(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  integer(c_int16_t) :: digest
+  integer(c_int32_t), intent(in) :: array(:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_int32_r4(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  integer(c_int16_t) :: digest
+  integer(c_int32_t), intent(in) :: array(:,:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_int32_r5(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  integer(c_int16_t) :: digest
+  integer(c_int32_t), intent(in) :: array(:,:,:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_int64_r1(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  integer(c_int16_t) :: digest
+  integer(c_int64_t), intent(in) :: array(:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_int64_r2(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  integer(c_int16_t) :: digest
+  integer(c_int64_t), intent(in) :: array(:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_int64_r3(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  integer(c_int16_t) :: digest
+  integer(c_int64_t), intent(in) :: array(:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_int64_r4(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  integer(c_int16_t) :: digest
+  integer(c_int64_t), intent(in) :: array(:,:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_int64_r5(array) result(digest)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  integer(c_int16_t) :: digest
+  integer(c_int64_t), intent(in) :: array(:,:,:,:,:)
+  type(fletcher16_type) :: checksum
+  call checksum%update(array)
+  digest = checksum%digest()
+end function
+
+function fletcher16_hex_real32_r1(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_float
+  character(len=4) :: hex4
+  real(c_float), intent(in) :: array(:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_real32_r2(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_float
+  character(len=4) :: hex4
+  real(c_float), intent(in) :: array(:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_real32_r3(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_float
+  character(len=4) :: hex4
+  real(c_float), intent(in) :: array(:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_real32_r4(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_float
+  character(len=4) :: hex4
+  real(c_float), intent(in) :: array(:,:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_real32_r5(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_float
+  character(len=4) :: hex4
+  real(c_float), intent(in) :: array(:,:,:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_real64_r1(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_double
+  character(len=4) :: hex4
+  real(c_double), intent(in) :: array(:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_real64_r2(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_double
+  character(len=4) :: hex4
+  real(c_double), intent(in) :: array(:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_real64_r3(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_double
+  character(len=4) :: hex4
+  real(c_double), intent(in) :: array(:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_real64_r4(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_double
+  character(len=4) :: hex4
+  real(c_double), intent(in) :: array(:,:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_real64_r5(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_double
+  character(len=4) :: hex4
+  real(c_double), intent(in) :: array(:,:,:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_int32_r1(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  character(len=4) :: hex4
+  integer(c_int32_t), intent(in) :: array(:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_int32_r2(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  character(len=4) :: hex4
+  integer(c_int32_t), intent(in) :: array(:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_int32_r3(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  character(len=4) :: hex4
+  integer(c_int32_t), intent(in) :: array(:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_int32_r4(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  character(len=4) :: hex4
+  integer(c_int32_t), intent(in) :: array(:,:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_int32_r5(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  character(len=4) :: hex4
+  integer(c_int32_t), intent(in) :: array(:,:,:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_int64_r1(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  character(len=4) :: hex4
+  integer(c_int64_t), intent(in) :: array(:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_int64_r2(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  character(len=4) :: hex4
+  integer(c_int64_t), intent(in) :: array(:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_int64_r3(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  character(len=4) :: hex4
+  integer(c_int64_t), intent(in) :: array(:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_int64_r4(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  character(len=4) :: hex4
+  integer(c_int64_t), intent(in) :: array(:,:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+function fletcher16_hex_int64_r5(array) result(hex4)
+  use, intrinsic :: iso_c_binding, only : c_int64_t
+  character(len=4) :: hex4
+  integer(c_int64_t), intent(in) :: array(:,:,:,:,:)
+  hex4 = to_hex(fletcher16(array))
+end function
+
+end module

--- a/src/fiat/util/ec_checksum.c
+++ b/src/fiat/util/ec_checksum.c
@@ -1,0 +1,71 @@
+/*
+ * (C) Copyright 2025- ECMWF.
+ * 
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include "ec_checksum.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef union {
+  ec_checksum_fletcher16_t checksum;
+  uint16_t      c[2];
+} Fletcher16;
+
+static void fletcher_reset(Fletcher16* f) {
+  f->c[0] = 0;
+  f->c[1] = 0;
+}
+
+static void fletcher_update(Fletcher16* f, const uint8_t* data, size_t size) {
+  uint32_t c0 = f->c[0];
+  uint32_t c1 = f->c[1];
+  while(size > 0) {
+    size_t blocklen = size;
+    if (blocklen > 5802) {
+      blocklen = 5802;
+    }
+    size -= blocklen;
+    do {
+      c0 = c0 + *data++;
+      c1 = c1 + c0;
+    } while (--blocklen);
+    c0 = c0 % 0xff;
+    c1 = c1 % 0xff;
+  }
+  f->c[0] = c0;
+  f->c[1] = c1;
+}
+
+static uint16_t fletcher_finish(const Fletcher16* f) {
+  uint32_t c0 = f->c[0];
+  uint32_t c1 = f->c[1];
+  return (c1 << 8 | c0);
+}
+
+void ec_checksum_fletcher16_reset(ec_checksum_fletcher16_t* checksum) {
+  fletcher_reset((Fletcher16*)checksum);
+}
+
+void ec_checksum_fletcher16_update(ec_checksum_fletcher16_t* checksum, const void* data, size_t bytes) {
+  fletcher_update((Fletcher16*)checksum, (const uint8_t*)data, bytes);
+}
+
+uint16_t ec_checksum_fletcher16_digest(const ec_checksum_fletcher16_t* checksum) {
+    return fletcher_finish((Fletcher16*)checksum);
+}
+
+uint16_t ec_checksum_fletcher16(const void* data, size_t bytes) {
+  ec_checksum_fletcher16_t checksum;
+  ec_checksum_fletcher16_reset(&checksum);
+  ec_checksum_fletcher16_update(&checksum,data,bytes);
+  return ec_checksum_fletcher16_digest(&checksum);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@
 
 if( HAVE_TESTS )
 
+set( CMAKE_Fortran_MODULE_DIRECTORY "" )
 if( HAVE_MPI AND MPIEXEC )
   set( LAUNCH ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1 )
 else()
@@ -126,6 +127,23 @@ ecbuild_add_test(
 ecbuild_add_test(
     TARGET  fiat_test_byteswap
     SOURCES test_byteswap.F90
+    LIBS    fiat
+    LINKER_LANGUAGE Fortran )
+
+# ----------------------------------------------------------------------------------------
+# Tests: fiat_test_checksum_c
+
+ecbuild_add_test(
+    TARGET  fiat_test_checksum_c 
+    SOURCES test_checksum.c
+    LIBS    fiat )
+
+# ----------------------------------------------------------------------------------------
+# Tests: fiat_test_checksum
+
+ecbuild_add_test(
+    TARGET  fiat_test_checksum
+    SOURCES test_checksum.F90
     LIBS    fiat
     LINKER_LANGUAGE Fortran )
 

--- a/tests/test_checksum.F90
+++ b/tests/test_checksum.F90
@@ -1,0 +1,763 @@
+! (C) Copyright 2025- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+!
+
+!
+! Test program to test ec_checksum_mod
+
+module fiat_test_fletcher16_type_mod
+! A helper module to initialise arrays used in the tests
+interface create_array
+module procedure :: create_array_real32_r1
+module procedure :: create_array_real32_r2
+module procedure :: create_array_real32_r3
+module procedure :: create_array_real32_r4
+module procedure :: create_array_real64_r1
+module procedure :: create_array_real64_r2
+module procedure :: create_array_real64_r3
+module procedure :: create_array_real64_r4
+module procedure :: create_array_int32_r1
+module procedure :: create_array_int32_r2
+module procedure :: create_array_int32_r3
+module procedure :: create_array_int32_r4
+module procedure :: create_array_int64_r1
+module procedure :: create_array_int64_r2
+module procedure :: create_array_int64_r3
+module procedure :: create_array_int64_r4
+end interface
+
+interface create_split_arrays
+module procedure :: create_split_arrays_real32_r1
+module procedure :: create_split_arrays_real64_r1
+end interface
+
+contains
+
+subroutine create_array_real32_r1(array)
+  use, intrinsic :: iso_c_binding
+  real(c_float), allocatable :: array(:)
+  integer :: i
+  integer, parameter :: N = 100000
+  allocate(array(N))
+  do i=1,N
+    array(i) = i
+  enddo
+end subroutine
+
+subroutine create_array_real32_r2(array)
+  use, intrinsic :: iso_c_binding
+  real(c_float), allocatable :: array(:,:)
+  integer :: i, j
+  integer, parameter :: N = 100000
+  integer, parameter :: Ni = N/200
+  integer, parameter :: Nj = N/Ni 
+  allocate(array(Ni,Nj))
+  do j=1,Nj
+    do i=1,Ni
+      array(i,j) = i + (j-1) * Ni
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_real32_r3(array)
+  use, intrinsic :: iso_c_binding
+  real(c_float), allocatable :: array(:,:,:)
+  integer :: i, j, k
+  integer, parameter :: Ni = 25
+  integer, parameter :: Nj = 8
+  integer, parameter :: Nk = 500
+  allocate(array(Ni,Nj,Nk))
+  do k=1,Nk
+    do j=1,Nj
+      do i=1,Ni
+        array(i,j,k) = i + (j-1) * Ni + (k-1) * (Ni * Nj)
+      enddo
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_real32_r4(array)
+  use, intrinsic :: iso_c_binding
+  real(c_float), allocatable :: array(:,:,:,:)
+  integer :: i, j, k, l
+  integer, parameter :: Ni = 25
+  integer, parameter :: Nj = 8
+  integer, parameter :: Nk = 10
+  integer, parameter :: Nl = 50
+  allocate(array(Ni,Nj,Nk,Nl))
+  do l=1,Nl
+    do k=1,Nk
+      do j=1,Nj
+        do i=1,Ni
+          array(i,j,k,l) = i + (j-1) * Ni + (k-1) * (Ni * Nj) + (l-1) * (Ni * Nj * Nk)
+        enddo
+      enddo
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_real64_r1(array)
+  use, intrinsic :: iso_c_binding
+  real(c_double), allocatable :: array(:)
+  integer :: i
+  integer, parameter :: N = 100000
+  allocate(array(N))
+  do i=1,N
+    array(i) = i
+  enddo
+end subroutine
+
+subroutine create_array_real64_r2(array)
+  use, intrinsic :: iso_c_binding
+  real(c_double), allocatable :: array(:,:)
+  integer :: i, j
+  integer, parameter :: N = 100000
+  integer, parameter :: Ni = N/200
+  integer, parameter :: Nj = N/Ni 
+  allocate(array(Ni,Nj))
+  do j=1,Nj
+    do i=1,Ni
+      array(i,j) = i + (j-1) * Ni
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_real64_r3(array)
+  use, intrinsic :: iso_c_binding
+  real(c_double), allocatable :: array(:,:,:)
+  integer :: i, j, k
+  integer, parameter :: Ni = 25
+  integer, parameter :: Nj = 8
+  integer, parameter :: Nk = 500
+  allocate(array(Ni,Nj,Nk))
+  do k=1,Nk
+    do j=1,Nj
+      do i=1,Ni
+        array(i,j,k) = i + (j-1) * Ni + (k-1) * (Ni * Nj)
+      enddo
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_real64_r4(array)
+  use, intrinsic :: iso_c_binding
+  real(c_double), allocatable :: array(:,:,:,:)
+  integer :: i, j, k, l
+  integer, parameter :: Ni = 25
+  integer, parameter :: Nj = 8
+  integer, parameter :: Nk = 10
+  integer, parameter :: Nl = 50
+  allocate(array(Ni,Nj,Nk,Nl))
+  do l=1,Nl
+    do k=1,Nk
+      do j=1,Nj
+        do i=1,Ni
+          array(i,j,k,l) = i + (j-1) * Ni + (k-1) * (Ni * Nj) + (l-1) * (Ni * Nj * Nk)
+        enddo
+      enddo
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_int32_r1(array)
+  use, intrinsic :: iso_c_binding
+  integer(c_int32_t), allocatable :: array(:)
+  integer :: i
+  integer, parameter :: N = 100000
+  allocate(array(N))
+  do i=1,N
+    array(i) = i
+  enddo
+end subroutine
+
+subroutine create_array_int32_r2(array)
+  use, intrinsic :: iso_c_binding
+  integer(c_int32_t), allocatable :: array(:,:)
+  integer :: i, j
+  integer, parameter :: N = 100000
+  integer, parameter :: Ni = N/200
+  integer, parameter :: Nj = N/Ni 
+  allocate(array(Ni,Nj))
+  do j=1,Nj
+    do i=1,Ni
+      array(i,j) = i + (j-1) * Ni
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_int32_r3(array)
+  use, intrinsic :: iso_c_binding
+  integer(c_int32_t), allocatable :: array(:,:,:)
+  integer :: i, j, k
+  integer, parameter :: Ni = 25
+  integer, parameter :: Nj = 8
+  integer, parameter :: Nk = 500
+  allocate(array(Ni,Nj,Nk))
+  do k=1,Nk
+    do j=1,Nj
+      do i=1,Ni
+        array(i,j,k) = i + (j-1) * Ni + (k-1) * (Ni * Nj)
+      enddo
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_int32_r4(array)
+  use, intrinsic :: iso_c_binding
+  integer(c_int32_t), allocatable :: array(:,:,:,:)
+  integer :: i, j, k, l
+  integer, parameter :: Ni = 25
+  integer, parameter :: Nj = 8
+  integer, parameter :: Nk = 10
+  integer, parameter :: Nl = 50
+  allocate(array(Ni,Nj,Nk,Nl))
+  do l=1,Nl
+    do k=1,Nk
+      do j=1,Nj
+        do i=1,Ni
+          array(i,j,k,l) = i + (j-1) * Ni + (k-1) * (Ni * Nj) + (l-1) * (Ni * Nj * Nk)
+        enddo
+      enddo
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_int64_r1(array)
+  use, intrinsic :: iso_c_binding
+  integer(c_int64_t), allocatable :: array(:)
+  integer :: i
+  integer, parameter :: N = 100000
+  allocate(array(N))
+  do i=1,N
+    array(i) = i
+  enddo
+end subroutine
+
+subroutine create_array_int64_r2(array)
+  use, intrinsic :: iso_c_binding
+  integer(c_int64_t), allocatable :: array(:,:)
+  integer :: i, j
+  integer, parameter :: N = 100000
+  integer, parameter :: Ni = N/200
+  integer, parameter :: Nj = N/Ni 
+  allocate(array(Ni,Nj))
+  do j=1,Nj
+    do i=1,Ni
+      array(i,j) = i + (j-1) * Ni
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_int64_r3(array)
+  use, intrinsic :: iso_c_binding
+  integer(c_int64_t), allocatable :: array(:,:,:)
+  integer :: i, j, k
+  integer, parameter :: Ni = 25
+  integer, parameter :: Nj = 8
+  integer, parameter :: Nk = 500
+  allocate(array(Ni,Nj,Nk))
+  do k=1,Nk
+    do j=1,Nj
+      do i=1,Ni
+        array(i,j,k) = i + (j-1) * Ni + (k-1) * (Ni * Nj)
+      enddo
+    enddo
+  enddo
+end subroutine
+
+subroutine create_array_int64_r4(array)
+  use, intrinsic :: iso_c_binding
+  integer(c_int64_t), allocatable :: array(:,:,:,:)
+  integer :: i, j, k, l
+  integer, parameter :: Ni = 25
+  integer, parameter :: Nj = 8
+  integer, parameter :: Nk = 10
+  integer, parameter :: Nl = 50
+  allocate(array(Ni,Nj,Nk,Nl))
+  do l=1,Nl
+    do k=1,Nk
+      do j=1,Nj
+        do i=1,Ni
+          array(i,j,k,l) = i + (j-1) * Ni + (k-1) * (Ni * Nj) + (l-1) * (Ni * Nj * Nk)
+        enddo
+      enddo
+    enddo
+  enddo
+end subroutine
+
+subroutine create_split_arrays_real32_r1(array1, array2)
+  use, intrinsic :: iso_c_binding
+  real(c_float), allocatable :: array1(:), array2(:)
+  integer :: i
+  integer, parameter :: N = 100000
+  integer :: N1, N2
+  N1 = N / 3
+  N2 = N - N1
+  allocate(array1(N1))
+  allocate(array2(N2))
+  do i=1,N1
+    array1(i) = i
+  enddo
+  do i=1,N2
+    array2(i) = N1 + i
+  enddo
+end subroutine
+
+subroutine create_split_arrays_real64_r1(array1, array2)
+  use, intrinsic :: iso_c_binding
+  real(c_double), allocatable :: array1(:), array2(:)
+  integer :: i
+  integer, parameter :: N = 100000
+  integer :: N1, N2
+  N1 = N / 3
+  N2 = N - N1
+  allocate(array1(N1))
+  allocate(array2(N2))
+  do i=1,N1
+    array1(i) = i
+  enddo
+  do i=1,N2
+    array2(i) = N1 + i
+  enddo
+end subroutine
+
+end module fiat_test_fletcher16_type_mod
+
+subroutine fail_impl(msg,line)
+  character(*) :: msg
+  integer :: line
+  write(0,'(A,I0,A)') "TEST FAILED in test_byteswap.F90 @ line ",line," :"
+  write(0,*) msg
+  stop 1
+end subroutine
+#define FAIL(msg) call fail_impl(msg,__LINE__)
+
+program test_checksum
+use ec_checksum_mod
+use fiat_test_fletcher16_type_mod
+use, intrinsic :: iso_c_binding
+implicit none
+
+call test_fletcher16_type_real32_r1()
+call test_fletcher16_type_real32_r2()
+call test_fletcher16_type_real32_r3()
+call test_fletcher16_type_real32_r4()
+call test_fletcher16_type_real64_r1()
+call test_fletcher16_type_real64_r2()
+call test_fletcher16_type_real64_r3()
+call test_fletcher16_type_real64_r4()
+call test_fletcher16_type_int32_r1()
+call test_fletcher16_type_int32_r2()
+call test_fletcher16_type_int32_r3()
+call test_fletcher16_type_int32_r4()
+call test_fletcher16_type_int64_r1()
+call test_fletcher16_type_int64_r2()
+call test_fletcher16_type_int64_r3()
+call test_fletcher16_type_int64_r4()
+call test_fletcher16_type_split_real32_r1()
+call test_fletcher16_type_split_real64_r1()
+call test_fletcher16_real32_r1()
+call test_fletcher16_real32_r2()
+call test_fletcher16_real32_r3()
+call test_fletcher16_real32_r4()
+call test_fletcher16_real64_r1()
+call test_fletcher16_real64_r2()
+call test_fletcher16_real64_r3()
+call test_fletcher16_real64_r4()
+call test_fletcher16_int32_r1()
+call test_fletcher16_int32_r2()
+call test_fletcher16_int32_r3()
+call test_fletcher16_int32_r4()
+call test_fletcher16_int64_r1()
+call test_fletcher16_int64_r2()
+call test_fletcher16_int64_r3()
+call test_fletcher16_int64_r4()
+
+write(0,'(A)') "SUCCESS"
+
+CONTAINS
+
+  subroutine test_fletcher16_type_real32_r1()
+    real(c_float), allocatable :: array(:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = '44c2'
+    write(0,'(A)') "test_fletcher16_type_real32_r1"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_real32_r2()
+    real(c_float), allocatable :: array(:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = '44c2'
+    write(0,'(A)') "test_fletcher16_type_real32_r2"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_real32_r3()
+    real(c_float), allocatable :: array(:,:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = '44c2'
+    write(0,'(A)') "test_fletcher16_type_real32_r3"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_real32_r4()
+    real(c_float), allocatable :: array(:,:,:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = '44c2'
+    write(0,'(A)') "test_fletcher16_type_real32_r4"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_real64_r1()
+    real(c_double), allocatable :: array(:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'ca21'
+    write(0,'(A)') "test_fletcher16_type_real64_r1"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_real64_r2()
+    real(c_double), allocatable :: array(:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'ca21'
+    write(0,'(A)') "test_fletcher16_type_real64_r2"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_real64_r3()
+    real(c_double), allocatable :: array(:,:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'ca21'
+    write(0,'(A)') "test_fletcher16_type_real64_r2"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_real64_r4()
+    real(c_double), allocatable :: array(:,:,:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'ca21'
+    write(0,'(A)') "test_fletcher16_type_real64_r4"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_int32_r1()
+    integer(c_int32_t), allocatable :: array(:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'e137'
+    write(0,'(A)') "test_fletcher16_type_int32_r1"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_int32_r2()
+    integer(c_int32_t), allocatable :: array(:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'e137'
+    write(0,'(A)') "test_fletcher16_type_int32_r2"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_int32_r3()
+    integer(c_int32_t), allocatable :: array(:,:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'e137'
+    write(0,'(A)') "test_fletcher16_type_int32_r3"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_int32_r4()
+    integer(c_int32_t), allocatable :: array(:,:,:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'e137'
+    write(0,'(A)') "test_fletcher16_type_int32_r4"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_int64_r1()
+    integer(c_int64_t), allocatable :: array(:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'a037'
+    write(0,'(A)') "test_fletcher16_type_int64_r1"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_int64_r2()
+    integer(c_int64_t), allocatable :: array(:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'a037'
+    write(0,'(A)') "test_fletcher16_type_int64_r2"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_int64_r3()
+    integer(c_int64_t), allocatable :: array(:,:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'a037'
+    write(0,'(A)') "test_fletcher16_type_int64_r2"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_int64_r4()
+    integer(c_int64_t), allocatable :: array(:,:,:,:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'a037'
+    write(0,'(A)') "test_fletcher16_type_int64_r4"
+    call create_array(array)
+    call checksum%update(array)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_split_real32_r1()
+    real(c_float), allocatable :: array1(:), array2(:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = '44c2'
+    write(0,'(A)') "test_fletcher16_type_split_real32_r1"
+    call create_split_arrays(array1, array2)
+    call checksum%update(array1)
+    call checksum%update(array2)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_type_split_real64_r1()
+    real(c_double), allocatable :: array1(:), array2(:)
+    type(fletcher16_type) :: checksum
+    character(len=4) :: expected = 'ca21'
+    write(0,'(A)') "test_fletcher16_type_split_real64_r1"
+    call create_split_arrays(array1, array2)
+    call checksum%update(array1)
+    call checksum%update(array2)
+    if (checksum%digest_hex() /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//checksum%digest_hex())
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_real32_r1()
+    real(c_float), allocatable :: array(:)
+    character(len=4) :: expected = '44c2'
+    write(0,'(A)') "test_fletcher16_real32_r1"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_real32_r2()
+    real(c_float), allocatable :: array(:,:)
+    character(len=4) :: expected = '44c2'
+    write(0,'(A)') "test_fletcher16_real32_r2"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_real32_r3()
+    real(c_float), allocatable :: array(:,:,:)
+    character(len=4) :: expected = '44c2'
+    write(0,'(A)') "test_fletcher16_real32_r3"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_real32_r4()
+    real(c_float), allocatable :: array(:,:,:,:)
+    character(len=4) :: expected = '44c2'
+    write(0,'(A)') "test_fletcher16_real32_r4"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_real64_r1()
+    real(c_double), allocatable :: array(:)
+    character(len=4) :: expected = 'ca21'
+    write(0,'(A)') "test_fletcher16_real64_r1"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_real64_r2()
+    real(c_double), allocatable :: array(:,:)
+    character(len=4) :: expected = 'ca21'
+    write(0,'(A)') "test_fletcher16_real64_r2"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_real64_r3()
+    real(c_double), allocatable :: array(:,:,:)
+    character(len=4) :: expected = 'ca21'
+    write(0,'(A)') "test_fletcher16_real64_r3"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_real64_r4()
+    real(c_double), allocatable :: array(:,:,:,:)
+    character(len=4) :: expected = 'ca21'
+    write(0,'(A)') "test_fletcher16_real64_r4"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_int32_r1()
+    integer(c_int32_t), allocatable :: array(:)
+    character(len=4) :: expected = 'e137'
+    write(0,'(A)') "test_fletcher16_int32_r1"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_int32_r2()
+    integer(c_int32_t), allocatable :: array(:,:)
+    character(len=4) :: expected = 'e137'
+    write(0,'(A)') "test_fletcher16_int32_r2"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_int32_r3()
+    integer(c_int32_t), allocatable :: array(:,:,:)
+    character(len=4) :: expected = 'e137'
+    write(0,'(A)') "test_fletcher16_int32_r3"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_int32_r4()
+    integer(c_int32_t), allocatable :: array(:,:,:,:)
+    character(len=4) :: expected = 'e137'
+    write(0,'(A)') "test_fletcher16_int32_r4"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_int64_r1()
+    integer(c_int64_t), allocatable :: array(:)
+    character(len=4) :: expected = 'a037'
+    write(0,'(A)') "test_fletcher16_int64_r1"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_int64_r2()
+    integer(c_int64_t), allocatable :: array(:,:)
+    character(len=4) :: expected = 'a037'
+    write(0,'(A)') "test_fletcher16_int64_r2"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_int64_r3()
+    integer(c_int64_t), allocatable :: array(:,:,:)
+    character(len=4) :: expected = 'a037'
+    write(0,'(A)') "test_fletcher16_int64_r3"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+  subroutine test_fletcher16_int64_r4()
+    integer(c_int64_t), allocatable :: array(:,:,:,:)
+    character(len=4) :: expected = 'a037'
+    write(0,'(A)') "test_fletcher16_int64_r4"
+    call create_array(array)
+    if (fletcher16_hex(array) /= expected) then
+      FAIL('checksum failed. Expected: '//expected//' , Computed: '//fletcher16_hex(array))
+    endif
+  end subroutine
+
+end program

--- a/tests/test_checksum.c
+++ b/tests/test_checksum.c
@@ -1,0 +1,81 @@
+/*
+ * (C) Copyright 2003- ECMWF.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation
+ * nor does it submit to any jurisdiction.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "fiat/ec_checksum.h"
+
+int err;
+
+void expect_equal(const uint16_t digest, const char* expected, int line_number) {
+    char hex[5];
+    memset(hex, ' ', 4);
+    snprintf(hex, 5, "%4x", digest);
+    for(int i=0; i<4; ++i) {
+        if(hex[i] == ' ') {
+            hex[i] = '0';
+        }
+    }
+    if(strncmp(hex, expected, strlen(expected)) != 0) {
+        fprintf(stderr,"ERROR: checksum '%s' different from expected '%s', in file %s, line %d\n",hex, expected, __FILE__, line_number);
+        err = 1;
+    }
+}
+#define EXPECT_EQUAL(digest, expected) expect_equal(digest, expected, __LINE__)
+
+int main(int argc, char* argv[]) {
+
+    const int N = 100000;
+    double array[N];
+    for( int i=0; i<N; ++i) {
+        array[i] = 1+i;
+    }
+
+    EXPECT_EQUAL(ec_checksum_fletcher16(array, N*sizeof(double)), "ca21");
+
+    ec_checksum_fletcher16_t f;
+    ec_checksum_fletcher16_reset(&f);
+    EXPECT_EQUAL(ec_checksum_fletcher16_digest(&f), "0000");
+
+    ec_checksum_fletcher16_reset(&f);
+    EXPECT_EQUAL(ec_checksum_fletcher16_digest(&f), "0000");
+
+    ec_checksum_fletcher16_update(&f, array, N*sizeof(double));
+    EXPECT_EQUAL(ec_checksum_fletcher16_digest(&f), "ca21");
+
+    const int N1 = N/3;
+    const int N2 = N - N1;
+    double array1[N1];
+    double array2[N2];
+    for( int i=0; i<N1; ++i) {
+        array1[i] = 1+i;
+    }
+    for( int i=0; i<N2; ++i) {
+        array2[i] = N1+1+i;
+    }
+
+    ec_checksum_fletcher16_reset(&f);
+    EXPECT_EQUAL(ec_checksum_fletcher16_digest(&f), "0000");
+
+    ec_checksum_fletcher16_update(&f, array1, N1*sizeof(double));
+    ec_checksum_fletcher16_update(&f, array2, N2*sizeof(double));
+    EXPECT_EQUAL(ec_checksum_fletcher16_digest(&f), "ca21");
+
+    if (err) {
+        fprintf(stderr,"TEST FAILED!\n");
+    }
+    else {
+        printf("TEST PASSED\n");
+    }
+    return err;
+}


### PR DESCRIPTION
This PR adds documentated API to do checksumming of Fortran arrays.

There are one-shot API to compute the checksum given arrays of various ranks and data types
```Fortran
use ec_checksum_mod, only : fletcher16, fletcher16_hex
integer :: checksum
character(len=4) :: checksum_hex
checksum     = fletcher16(array)
checksum_hex = fletcher16_hex(array)
```

There is an API to compute a checksum that can be created by combining multiple arrays
```Fortran
use ec_checksum_mod, only : fletcher16_type
type(fletcher16_type) :: checksummer
integer :: checksum
character(len=4) :: checksum_hex
call checksummer%update(array1)
call checksummer%update(array2)
checksum     = checksummer%digest()
checksum_hex = checksummer%digest_hex()
```