### PR TITLE
Enable OpenMP for C source code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 ecbuild_add_option( FEATURE OMP
                     DESCRIPTION "support for OpenMP shared memory parallelism"
-                    REQUIRED_PACKAGES "OpenMP COMPONENTS Fortran" )
+                    REQUIRED_PACKAGES "OpenMP COMPONENTS Fortran C" )
 
 ecbuild_add_option( FEATURE MPI
                     DESCRIPTION "Support for MPI distributed parallelism"

--- a/src/fiat/CMakeLists.txt
+++ b/src/fiat/CMakeLists.txt
@@ -101,7 +101,7 @@ else()
 endif()
 
 if( HAVE_OMP )
-    target_link_libraries( fiat PRIVATE OpenMP::OpenMP_Fortran )
+    target_link_libraries( fiat PRIVATE OpenMP::OpenMP_Fortran OpenMP::OpenMP_C )
 endif()
 
 fiat_target_ignore_missing_symbols( TARGET fiat SYMBOLS


### PR DESCRIPTION
The purpose of this pull request is to enable OpenMP flags for the C source code of fiat. In particular, the file linux_bind.c has to be compiled using these flags.

Tested in Intel and nvhpc environments.

