### PR TITLE
Use Fortran OpenMP in linux_bind.c

### DIFF
--- a/src/fiat/system/internal/linux_bind.c
+++ b/src/fiat/system/internal/linux_bind.c
@@ -10,7 +10,7 @@
  * nor does it submit to any jurisdiction.
  */
 
-#if defined(LINUX) && !defined(_CRAYC) && !defined(ECMWF)
+#if defined(LINUX) && !defined(_CRAYC)
 
 #define _GNU_SOURCE
 
@@ -19,12 +19,9 @@
 #include <unistd.h>
 #include <string.h>
 #include <ctype.h>
-
-#ifdef _OPENMP
-#include <omp.h>
-#endif
-
 #include <sched.h>
+
+#include "oml.h"
 
 static char * getcpumask (char *buffer, size_t size)
 {
@@ -44,162 +41,140 @@ static char * getcpumask (char *buffer, size_t size)
   return buffer;
 }
 
+static void function_linux_bind_dump_parallel( void* args ) {
+  // This function must be called within an OMP PARALLEL region
+
+  // Unpack args
+  FILE* fp = (FILE*)args;
+
+  char buffer[1048576]; /* 1 megabyte */
+  int nomp = oml_get_max_threads();
+  int iomp = oml_get_thread_num();
+  for (int i = 0; i < nomp; i++) {
+    if (i == iomp) {
+      // OMP CRITICAL REGION implemented with locks
+      oml_set_lock();
+      fprintf (fp, "\n                                                    mask = %s iomp = %2d",
+               getcpumask (buffer, sizeof (buffer)), iomp);
+      oml_unset_lock();
+    }
+    oml_barrier();
+  }
+  oml_barrier();
+}
+
 void linux_bind_dump_ (int * prank, int * psize)
 {
-  int rank = *prank;
-  int size = *psize;
-  int icpu;
-  unsigned int ncpu;
-  FILE * fp = NULL;
+  const int rank = *prank;
+  const int size = *psize;
+  FILE* fp = NULL;
   char f[256];
   char host[255];
-  int nomp =
-#ifdef _OPENMP
-    omp_get_max_threads ()
-#else
-    1
-#endif
-  ;
-
-  ncpu = sysconf (_SC_NPROCESSORS_CONF);
+  char buffer[1024];
+  const int nomp = oml_get_max_threads();
+  const unsigned int ncpu = sysconf (_SC_NPROCESSORS_CONF);
 
   sprintf (f, "linux_bind.%6.6d.txt", rank);
   fp = fopen (f, "w");
 
-  if (gethostname (host, 255) != 0)
+  if (gethostname (host, 255) != 0) {
        strcpy (host, "unknown");
+  }
 
   fprintf (fp, " rank = %6d", rank);
   fprintf (fp, " host = %9s", host);
   fprintf (fp, " ncpu = %2d", ncpu);
   fprintf (fp, " nomp = %2d", nomp);
+  fprintf (fp, " mask = %s", getcpumask (buffer, sizeof (buffer)));
 
-  {
-    char buffer[1024];
-    fprintf (fp, " mask = %s", getcpumask (buffer, sizeof (buffer)));
-  }
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-  {
-    char buffer[1024];
-    int iomp =
-#ifdef _OPENMP
-      omp_get_thread_num ()
-#else
-      1
-#endif
-    ;
-    int i;
-    for (i = 0; i < nomp; i++)
-      {
-        if (i == iomp)
-          {
-#ifdef _OPENMP
-#pragma omp critical
-#endif
-            fprintf (fp, "\n                                                    mask = %s iomp = %2d",
-                     getcpumask (buffer, sizeof (buffer)), iomp);
-          }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif
-      }
-#ifdef _OPENMP
-#pragma omp barrier
-#endif
-  }
+  oml_init_lock();
+  oml_run_parallel (function_linux_bind_dump_parallel, fp);
+  oml_destroy_lock();
 
   fprintf (fp, "\n");
-
   fclose (fp);
-
 }
 
 #define LINUX_BIND_TXT "linux_bind.txt"
 
-void linux_bind_ (int * prank, int * psize)
-{
-  int rank = *prank;
-  int size = *psize;
-  FILE * fp;
-  int i;
-  size_t len  = 256;
-  char * buf = (char*)malloc (len);
-  const char * EC_LINUX_BIND;
+typedef struct {
+  const char* linux_bind_txt;
+  const char* buf;
+  const int rank;
+} function_linux_bind_parallel_args_t;
 
-  EC_LINUX_BIND = getenv ("EC_LINUX_BIND");
+static void function_linux_bind_parallel(void* args) {
+  // This function must be called within an OMP PARALLEL region
 
-  if (EC_LINUX_BIND == NULL)
-    EC_LINUX_BIND = LINUX_BIND_TXT;
+  // Unpack args
+  function_linux_bind_parallel_args_t* function_args = (function_linux_bind_parallel_args_t*)args;
+  const char* linux_bind_txt = function_args->linux_bind_txt;
+  const char* buf = function_args->buf;
+  const int rank = function_args->rank;
+  const int iomp = oml_get_thread_num();
 
-  fp = fopen (EC_LINUX_BIND, "r");
-
-  if (fp == NULL)
-    {
-      // Willem Deconinck: Comment out as this pollutes logs
-      // fprintf (stderr, "`%s' was not found\n", EC_LINUX_BIND);
-      goto end;
+  const char* c = buf;
+  // Move c to position for this omp thread
+  for (int jomp = 0; jomp < iomp; jomp++) {
+    while (*c && isdigit (*c)) {
+      c++;
     }
-
-  for (i = 0; i < rank+1; i++)
-    {
-      if (getline (&buf, &len, fp) == -1)
-        {
-          fprintf (stderr, "Unexpected EOF while reading `" LINUX_BIND_TXT "'\n");
-          goto end;
-        }
+    while (*c && (! isdigit (*c))) {
+      c++;
     }
-
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
-  {
-    char * c;
-    cpu_set_t mask;
-    int iomp =
-#ifdef _OPENMP
-      omp_get_thread_num ()
-#else
-      1
-#endif
-    ;
-    int jomp, icpu;
-
-    for (jomp = 0, c = buf; jomp < iomp; jomp++)
-      {
-        while (*c && isdigit (*c))
-          c++;
-        while (*c && (! isdigit (*c)))
-          c++;
-        if (*c == '\0')
-          {
-            fprintf (stderr, "Unexpected end of line while reading `" LINUX_BIND_TXT "'\n");
-            goto end_parallel;
-          }
-      }
-
-    CPU_ZERO (&mask);
-
-    for (icpu = 0; isdigit (*c); icpu++, c++)
-      if (*c != '0')
-        CPU_SET (icpu, &mask);
-
-    sched_setaffinity (0, sizeof (mask), &mask);
-
-end_parallel:
-
-    c = NULL;
-
+    if (*c == '\0') {
+      fprintf (stderr, "Unexpected end of line while reading '%s' on rank %d, thread %d (linux_bind.c:%d)\n", linux_bind_txt, rank, iomp, __LINE__);
+      return;
+    }
   }
 
-end:
+  cpu_set_t mask;
+  CPU_ZERO (&mask);
 
-  if (fp != NULL)
-    fclose (fp);
+  for (int icpu = 0; isdigit (*c); icpu++, c++) {
+    if (*c != '0') {
+      CPU_SET (icpu, &mask);
+    }
+  }
 
-  free (buf);
+  sched_setaffinity (0, sizeof (mask), &mask);
+}
+
+void linux_bind_ (int * prank, int * psize)
+{
+  const int rank = *prank;
+  const int size = *psize;
+  FILE* fp;
+  size_t len = 0;
+  char buffer[1024];
+  char* buf = buffer;
+  const char* linux_bind_txt;
+
+  linux_bind_txt = getenv ("EC_LINUX_BIND");
+
+  if (linux_bind_txt == NULL) {
+    linux_bind_txt = LINUX_BIND_TXT;
+  }
+
+  fp = fopen (linux_bind_txt, "r");
+
+  if (fp == NULL) {
+      // Willem Deconinck: Commented out as this pollutes logs
+      // fprintf (stderr, "`%s' was not found\n", EC_LINUX_BIND);
+      return;
+  }
+
+  for (int i = 0; i < rank+1; i++) {
+    if (getline (&buf, &len, fp) == -1) {
+      fprintf (stderr, "Unexpected end of file while reading '%s' on rank %d (linux_bind.c:%d)\n", linux_bind_txt, rank, __LINE__);
+      fclose (fp);
+      return;
+    }
+  }
+  fclose (fp);
+
+  function_linux_bind_parallel_args_t args = {.linux_bind_txt=linux_bind_txt, .buf=buf, .rank=rank};
+  oml_run_parallel (function_linux_bind_parallel, &args);
 }
 
 #else


### PR DESCRIPTION
The issue is described in #53 where linux_bind.c was not compiled with OpenMP.
This PR avoids requirement to compile this file with the C-compiler's OpenMP flags,
which in some instances may have a different OpenMP implementation/runtime than the Fortran compiler.
Instead the file is adapted to make use of OML which uses the Fortran OpenMP runtime.
This is in line with how DR_HOOK uses OpenMP as well.

I verified this to give the same results as the approach in #53 where OpenMP was enabled for linux_bind.c
@pmarguinaud please review and verify if this is also OK for you.

We can make a quick tagged release with the fix if needed urgently.