### PR TITLE
Fix scale of getmaxrss for MacOS

### DIFF
--- a/src/fiat/system/getmaxrss.c
+++ b/src/fiat/system/getmaxrss.c
@@ -14,7 +14,11 @@ typedef  long long int  ll_t;
 ll_t
 getmaxrss_()
 {
-  const ll_t scaler = 1024; /* in kilobytes */
+#ifdef __APPLE__
+  const ll_t scaler = 1;    /* ru_maxrss is defined in bytes */
+#else
+  const ll_t scaler = 1024; /* ru_maxrss is defened in kilobytes */
+#endif
   ll_t rc = 0;
   struct rusage r;
   rc = getrusage(RUSAGE_SELF, &r);


### PR DESCRIPTION
On MacOS the value stored in `ru_maxrss` obtained via the the function `getrusage(RUSAGE_SELF, ...)` is in bytes, whereas on other platforms this is in kilobytes.
This PR fixes the result on MacOS to be scaled correctly. This should fix issue #58 where the memory reported for MacOS is off by scaling of 1024.