### PR TITLE
Fix errors when building DrHook & PAPI is not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ ecbuild_add_option( FEATURE MPI
                     REQUIRED_PACKAGES "MPI COMPONENTS Fortran" )
 
 ecbuild_add_option( FEATURE DR_HOOK_PAPI
+                    DEFAULT OFF
                     DESCRIPTION "Support for HW counters in DR_HOOK via PAPI"
                     REQUIRED_PACKAGES "PAPI")
 

--- a/src/fiat/drhook/extensions/papi/drhook_papi.c
+++ b/src/fiat/drhook/extensions/papi/drhook_papi.c
@@ -281,17 +281,18 @@ int drhook_papi_start_threads(int* events){
       snprintf(pmsg,STD_MSG_LEN,"DRHOOK:PAPI: Error, add_event failed: %d (%s)",papiErr,PAPI_strerror(papiErr));
       printf("%s\n",pmsg);
       if (papiErr == PAPI_EINVAL)
-        printf("Invalid argument\n");
+        printf("Invalid argument. ");
       else if (papiErr == PAPI_ENOMEM)
-        printf("Out of memory\n");
+        printf("Out of memory. ");
       else if (papiErr == PAPI_ENOEVST)
-        printf("EventSet does not exist\n");
+        printf("EventSet does not exist. ");
       else if (papiErr == PAPI_EISRUN)
-        printf("EventSet is running\n");
+        printf("EventSet is running. ");
       else if (papiErr == PAPI_ECNFLCT)
-        printf("Conflict\n");
+        printf("Conflict. ");
       else if (papiErr == PAPI_ENOEVNT)
-        printf("Preset not available\n");
+        printf("Preset not available. ");
+      printf("This is an error within PAPI and not DrHook. DrHook is only reporting the error it received.\n");
       return 0;
     }
     else {


### PR DESCRIPTION
This PR changes DrHook's PAPI extension to be `OFF` by default. It also clarifies that errors generated when searching for PAPI events are from PAPI and not DrHook directly.