### PR TITLE
Robust definition of parkind1 JPIA

### DIFF
--- a/src/fiat/util/ec_parkind.F90
+++ b/src/fiat/util/ec_parkind.F90
@@ -12,7 +12,9 @@ MODULE EC_PARKIND
 !
 !     *** Define usual kinds for strong typing ***
 !
+USE, INTRINSIC :: ISO_C_BINDING, ONLY : C_INTPTR_T
 IMPLICIT NONE
+PRIVATE :: C_INTPTR_T
 SAVE
 !
 !     Integer Kinds
@@ -20,6 +22,7 @@ SAVE
 !
 INTEGER, PARAMETER :: JPIM = SELECTED_INT_KIND(9)
 INTEGER, PARAMETER :: JPIB = SELECTED_INT_KIND(12)
+INTEGER, PARAMETER :: JPIA = C_INTPTR_T
 
 !
 !     Real Kinds

--- a/src/parkind/CMakeLists.txt
+++ b/src/parkind/CMakeLists.txt
@@ -18,10 +18,6 @@ foreach( prec sp dp )
               parkind2.F90
     )
 
-    if( EC_OS_BITS EQUAL "64" )
-      target_compile_definitions( ${target} PRIVATE ADDRESS64 )
-    endif()
-
     fiat_target_fortran_module_directory(
       TARGET            ${target}
       MODULE_DIRECTORY  ${CMAKE_BINARY_DIR}/module/${target}

--- a/src/parkind/parkind1.F90
+++ b/src/parkind/parkind1.F90
@@ -12,7 +12,9 @@ MODULE PARKIND1
 !
 !     *** Define usual kinds for strong typing ***
 !
+USE, INTRINSIC :: ISO_C_BINDING, ONLY : C_INTPTR_T
 IMPLICIT NONE
+PRIVATE :: C_INTPTR_T
 SAVE
 !
 !     Integer Kinds
@@ -25,11 +27,7 @@ INTEGER, PARAMETER :: JPIB = SELECTED_INT_KIND(12)
 
 !Special integer type to be used for sensative adress calculations
 !should be *8 for a machine with 8byte adressing for optimum performance
-#ifdef ADDRESS64
-INTEGER, PARAMETER :: JPIA = JPIB
-#else
-INTEGER, PARAMETER :: JPIA = JPIM
-#endif
+INTEGER, PARAMETER :: JPIA = C_INTPTR_T
 
 !
 !     Real Kinds

--- a/tests/test_install/main.F90
+++ b/tests/test_install/main.F90
@@ -13,10 +13,11 @@ program main
   use yomhook      ! assert found
   use mpl_module   ! assert found
 ! From library parkind_(dp|sp)
-  use parkind1, only: JPRB ! assert found
+  use parkind1, only: JPRB, JPIA ! assert found
 
 implicit none
 
 write(0,*) "JPRB =",JPRB ! depending on link with parkind_sp or parkind_dp this will print 4 or 8
+write(0,*) "JPIA =",JPIA ! depending system this will print 4 or 8
 
 end program


### PR DESCRIPTION
JPIA is defining how many bytes are used to define an address.
This PR adapts parkind1 to define JPIA based on intrinsic C_INTPTR_T rather than externally provided ADDRESS64 preprocessor definition which proved to be faulty for certain platforms. Not sure yet how that could have happened.

Big thanks to Sami for discovering this problem, and providing a robust fix.

I have also added JPIA to EC_PARKIND which is precision-independent,  not including JPRB.