### PR TITLE
Fix incorrect Intel compiler flag (fixes #64)

### DIFF
--- a/src/fiat/CMakeLists.txt
+++ b/src/fiat/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 if( CMAKE_Fortran_COMPILER_ID MATCHES "Intel" )
   ## To disable checking of argument correctness of dummy mpi symbols
-  ecbuild_add_fortran_flags( -nowarn nointerfaces NO_FAIL )
+  ecbuild_add_fortran_flags( -warn nointerfaces NO_FAIL )
 endif()
 
 if( CMAKE_Fortran_COMPILER_ID MATCHES "GNU" )


### PR DESCRIPTION
Replace the intel flag `-nowarn nointerfaces` with `-warn nointerfaces` as proposed in #64 