### PR TITLE
Reenable MPL_FO8 without MPI-enabled compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,10 +60,6 @@ ecbuild_add_option( FEATURE MPL_F77_DEPRECATED
                     DESCRIPTION "Compile deprecated mpif.h MPL instead of MPI_F08 version"
                     REQUIRED_PACKAGES "MPI COMPONENTS Fortran"
                     DEFAULT OFF )
-if (NOT HAVE_MPI AND NOT HAVE_MPL_F77_DEPRECATED)
-    ecbuild_warn("Dummy implementation mpi_serial does not support MPI_F08; Turning MPL_F77_DEPRECATED feature ON")
-    set (HAVE_MPL_F77_DEPRECATED 1)
-endif()
 
 ecbuild_add_option( FEATURE MPL_CHECK_CONTIG
                     DESCRIPTION "Enable runtime check of contiguity of array arguments passed to MPL routines"

--- a/src/fiat/mpl/internal_f08/mpi_f08_dummy_mod.F90
+++ b/src/fiat/mpl/internal_f08/mpi_f08_dummy_mod.F90
@@ -12,7 +12,7 @@ MODULE MPI_F08
 
 INTEGER :: MPI_UNDEFINED, MPI_MAX_ERROR_STRING, MPI_ANY_TAG, MPI_ANY_SOURCE, &
  &         MPI_IDENT, MPI_CONGRUENT, MPI_SIMILAR, MPI_THREAD_SINGLE, MPI_THREAD_MULTIPLE, &
- &         MPI_MODE_RDONLY, MPI_MODE_WRONLY, MPI_MODE_CREATE, MPI_TYPE_SIZE
+ &         MPI_MODE_RDONLY, MPI_MODE_WRONLY, MPI_MODE_CREATE
 
 !! dummy type definitions
 !!========================
@@ -59,6 +59,11 @@ TYPE(MPI_REQUEST)  :: MPI_REQUEST_NULL
 TYPE(MPI_COMM)     :: MPI_COMM_WORLD, MPI_COMM_NULL
 
 TYPE(MPI_INFO)     :: MPI_INFO_NULL
+
+!! symbols defined in mpi_serial library, and picked up via a 'USE MPL_MPIF' important statement
+!!==============================================================================================
+
+EXTERNAL :: MPI_COMM_SIZE, MPI_TYPE_SIZE, MPI_ALLREDUCE, MPI_COMM_CREATE, MPI_COMM_GROUP
 
 END MODULE MPI_F08
 


### PR DESCRIPTION
 * declare required mpi_serial symbols as external in mpi_f08_dummy_mod