### PR TITLE
Export availability of MPL_F08 to downstream packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,12 @@ add_subdirectory(tests)
 
 ### Export
 
+if (fiat_HAVE_MPL_F77_DEPRECATED)
+set (fiat_HAVE_MPL_F08 0)
+else()
+set (fiat_HAVE_MPL_F08 1)
+endif()
+
 ecbuild_install_project( NAME fiat )
 
 ecbuild_print_summary()

--- a/cmake/fiat-import.cmake.in
+++ b/cmake/fiat-import.cmake.in
@@ -17,6 +17,8 @@ set( fiat_HAVE_OMP    @fiat_HAVE_OMP@ )
 set( fiat_HAVE_FCKIT  @fiat_HAVE_FCKIT@ )
 set( fiat_HAVE_SINGLE_PRECISION   @fiat_HAVE_SINGLE_PRECISION@ )
 set( fiat_HAVE_DOUBLE_PRECISION   @fiat_HAVE_DOUBLE_PRECISION@ )
+set( fiat_HAVE_MPL_F08 @fiat_HAVE_MPL_F08@ )
+
 set( fiat_SOURCE_FILENAMES      @fiat_SOURCE_FILENAMES@ )
 
 if( fiat_HAVE_OMP AND NOT TARGET OpenMP::OpenMP_Fortran )

--- a/src/programs/CMakeLists.txt
+++ b/src/programs/CMakeLists.txt
@@ -16,6 +16,15 @@ foreach( lang ${langs} )
   set( EC_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} ${CMAKE_${lang}_FLAGS_${CMAKE_BUILD_TYPE_CAPS}}" )
 endforeach()
 
+set (MPL_BACKEND "")
+if (HAVE_MPI)
+  if (HAVE_MPL_F77_DEPRECATED)
+    set(MPL_BACKEND " (backend=mpif)")
+  else()
+    set(MPL_BACKEND " (backend=mpi_f08)")
+  endif()
+endif()
+
 configure_file( ${tool}.in ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${tool} @ONLY )
 
 file(COPY ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${tool}

--- a/src/programs/fiat.in
+++ b/src/programs/fiat.in
@@ -50,7 +50,7 @@ info()
   echo "    flags         : @EC_Fortran_FLAGS@"
   echo ""
   echo "Features:"
-  echo "  MPI             : @fiat_HAVE_MPI@"
+  echo "  MPI             : @fiat_HAVE_MPI@@MPL_BACKEND@"
   echo "  OMP             : @fiat_HAVE_OMP@"
   echo "  FCKIT           : @fiat_HAVE_FCKIT@"
   echo ""

--- a/tests/test_install/CMakeLists.txt
+++ b/tests/test_install/CMakeLists.txt
@@ -12,6 +12,8 @@ project( fiat_test_install VERSION 0.0.0 LANGUAGES Fortran )
 
 find_package( fiat REQUIRED )
 
+message("fiat_HAVE_MPL_F08: ${fiat_HAVE_MPL_F08}")
+
 if( TARGET parkind_dp )
 ecbuild_add_executable( TARGET  main_dp
                         SOURCES main.F90


### PR DESCRIPTION
This allows downstream packages like ectrans to assert that fiat has been compiled with MPI_F08 backend for MPL.
Code needed downstream:
```cmake
find_package(fiat ... )
if (fiat_HAVE_MPL_F08)
  ...
endif()
```