### PR TITLE
Fix compilation for Classic Flang, including AOCC

### DIFF
--- a/src/fiat/util/ec_checksum.F90
+++ b/src/fiat/util/ec_checksum.F90
@@ -49,14 +49,15 @@ private
 public :: fletcher16_type, fletcher16, fletcher16_hex
 
 #define fletcher16_digest_t c_int16_t
-#ifdef __NVCOMPILER
+
+! Workaround an internal compiler error in function digest() for NVHPC <= 22 and Classic Flang (PGI-based)
+#if defined(__NVCOMPILER)
 #if __NVCOMPILER_MAJOR__ <= 22
-! Workaround an internal compiler error in function digest()
 #undef  fletcher16_digest_t
 #define fletcher16_digest_t c_int32_t
 #endif
-#endif
-#ifdef AOCC
+#elif defined(__FLANG)
+! Classic Flang (PGI-based), includes also AOCC/4.0. Note, LLVM Flang defines __flang__ and __llvm__ instead.
 #undef  fletcher16_digest_t
 #define fletcher16_digest_t c_int32_t
 #endif


### PR DESCRIPTION
Addresses #84.  This is basically what was done for NVHPC although I haven't done any version check.  I don't know if there is a better way of doing this?  I am just passing AOCC via CMAKE_Fortran_FLAGS rather than relying on cmake's compiler detection.