### PR TITLE
Add lockfile RESOURCE_LOCK for DrHook tests that WILL_FAIL

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,9 @@ add_test(NAME fiat_test_abort_exception_handler
   "-DEXECUTABLE=$<TARGET_FILE:fiat-test-abort-exception-handler>"
   "-DLAUNCH=${LAUNCH}"
   "-DPASS_REGULAR_EXPRESSION=problem in function_2"
-  -P ${CMAKE_CURRENT_SOURCE_DIR}/test_program_output.cmake )
+  -P ${CMAKE_CURRENT_SOURCE_DIR}/test_program_output.cmake
+  RESOURCE_LOCK drhook_lockfile
+)
 endif()
 
 add_subdirectory( drhook )
@@ -83,6 +85,7 @@ add_test( NAME fiat_test_drhook_abort_abor1fl
 set_tests_properties(fiat_test_drhook_abort_abor1fl PROPERTIES
     ENVIRONMENT "DR_HOOK_ASSERT_MPI_INITIALIZED=0"
     PASS_REGULAR_EXPRESSION "ABOR1.*EC_DRHOOK.*\[DrHookCallTree\]"
+    RESOURCE_LOCK drhook_lockfile
 )
 
 add_test( NAME fiat_test_drhook_abort_custom_abort
@@ -90,6 +93,7 @@ add_test( NAME fiat_test_drhook_abort_custom_abort
 set_tests_properties(fiat_test_drhook_abort_custom_abort PROPERTIES
     ENVIRONMENT "CUSTOM_ABORT=1;DR_HOOK_ASSERT_MPI_INITIALIZED=0"
     PASS_REGULAR_EXPRESSION "custom_abort.*EC_DRHOOK.*\[DrHookCallTree\]"
+    RESOURCE_LOCK drhook_lockfile
 )
 
 # ----------------------------------------------------------------------------------------
@@ -102,7 +106,9 @@ ecbuild_add_test(
     DEFINITIONS ${FCKIT_DEFINITIONS})
 set_tests_properties(fiat_test_drhook_fortran PROPERTIES
     ENVIRONMENT "MPL=0;DR_HOOK_ASSERT_MPI_INITIALIZED=0;DR_HOOK_OPT=NOPROPAGATE_SIGNALS"
-    PASS_REGULAR_EXPRESSION "EC_DRHOOK.*\[DrHookCallTree\]" )
+    PASS_REGULAR_EXPRESSION "EC_DRHOOK.*\[DrHookCallTree\]"
+    RESOURCE_LOCK drhook_lockfile
+)
 
 
 # ----------------------------------------------------------------------------------------
@@ -239,7 +245,9 @@ add_test(NAME fiat_test_abor1
       COMMAND ${CMAKE_COMMAND}
       "-DEXECUTABLE=$<TARGET_FILE:fiat-test-abor1>"
       "-DPASS_REGULAR_EXPRESSION=ABOR1.*aborting from OpenMP parallel region"
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/test_program_output.cmake )
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/test_program_output.cmake
+      RESOURCE_LOCK drhook_lockfile
+)
 
 #-----------------------------------------------------------------------------------------
 # Tests:  fiat_test_alltoallv

--- a/tests/drhook/CMakeLists.txt
+++ b/tests/drhook/CMakeLists.txt
@@ -45,14 +45,14 @@ ecbuild_add_test( TARGET fiat_test_drhook_ex1
                   ENVIRONMENT DR_HOOK=1 DR_HOOK_TRAPFPE=1 DR_HOOK_ASSERT_MPI_INITIALIZED=0 DR_HOOK_OPT=NOPROPAGATE_SIGNALS )
 
 if( FPE_TRAPPING_SUPPORTED )
-  set_tests_properties( fiat_test_drhook_ex1 PROPERTIES WILL_FAIL TRUE )
+  set_tests_properties( fiat_test_drhook_ex1 PROPERTIES WILL_FAIL TRUE RESOURCE_LOCK drhook_lockfile )
 endif()
 
 # Test watchpoint point trapping
 ecbuild_add_test( TARGET fiat_test_drhook_ex2
                   COMMAND drhook_ex2
                   ENVIRONMENT DR_HOOK=1 DR_HOOK_ASSERT_MPI_INITIALIZED=0 DR_HOOK_OPT=NOPROPAGATE_SIGNALS )
-set_tests_properties( fiat_test_drhook_ex2 PROPERTIES WILL_FAIL TRUE )
+set_tests_properties( fiat_test_drhook_ex2 PROPERTIES WILL_FAIL TRUE RESOURCE_LOCK drhook_lockfile )
 
 # Play with profiling options
 ecbuild_add_test( TARGET fiat_test_drhook_ex3
@@ -64,7 +64,7 @@ ecbuild_add_test( TARGET fiat_test_drhook_ex4
                   COMMAND drhook_ex4
                   ENVIRONMENT DR_HOOK=1 SIGFPE=1 DR_HOOK_ASSERT_MPI_INITIALIZED=0 DR_HOOK_OPT=NOPROPAGATE_SIGNALS )
 if( FPE_TRAPPING_SUPPORTED )
-  set_tests_properties( fiat_test_drhook_ex4 PROPERTIES WILL_FAIL TRUE )
+  set_tests_properties( fiat_test_drhook_ex4 PROPERTIES WILL_FAIL TRUE RESOURCE_LOCK drhook_lockfile )
 endif()
 
 # Play MPI and dr_hook together


### PR DESCRIPTION
This addresses #82.

This allows users to run tests in parallel without WILL_FAIL DrHook tests hanging and timing out. This happens because DrHook has contention on the drhook_lock lockfile between different test executions. This lockfile is used as a lock for entering the signal handler, and so if one test sets it in parallel with another, the second test case will hang as it can never handle the signal.

This temporary fix is to use cmake to add a RESOURCE_LOCK for the lockfile, which prevents multiple tests requiring the lockfile from running in parallel - they must be serial. A better fix would be to allow the user to specify the lockfile name (with the current 'drhook_lock' being a default) and then tests can create unique lockfiles. However, this should be part of a larger refactor of signal handling.