### PR TITLE
Remove intel-oneapi-mpi-devel from installation script

### DIFF
--- a/.github/tools/install-intel-oneapi.sh
+++ b/.github/tools/install-intel-oneapi.sh
@@ -10,5 +10,4 @@ sudo apt-get update
 sudo apt-get install \
     intel-oneapi-compiler-fortran-$version \
     intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-$version \
-    intel-oneapi-mpi-devel-2021.10.0 \
     intel-oneapi-mkl-$version


### PR DESCRIPTION
Removed as it was causing the Intel compiler confusion with OpenMPI and causing builds to fail, as seen in #111.