### PR TITLE
Apple Silicon HW FPE trapping & signal handling

### DIFF
--- a/src/fiat/drhook/drhook.c
+++ b/src/fiat/drhook/drhook.c
@@ -207,7 +207,108 @@ extern int feenableexcept(int excepts);
 extern int fedisableexcept(int excepts);
 extern int fegetexcept(void);
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && defined(__arm64__)
+// Borrowed from Atlas https://github.com/ecmwf/atlas/blob/develop/src/atlas/library/FloatingPointExceptions.cc
+static unsigned long long fenv_to_fpcr(unsigned int fenv_flag) {
+  unsigned long long fpcr_flags = 0;
+  if (fenv_flag & FE_INEXACT ) {
+    fpcr_flags |= __fpcr_trap_inexact;
+  }
+  if (fenv_flag & FE_UNDERFLOW ) {
+    fpcr_flags |= __fpcr_trap_underflow;
+  }
+  if (fenv_flag & FE_OVERFLOW ) {
+    fpcr_flags |= __fpcr_trap_overflow;
+  }
+  if (fenv_flag & FE_DIVBYZERO ) {
+    fpcr_flags |= __fpcr_trap_divbyzero;
+  }
+  if (fenv_flag & FE_INVALID ) {
+    fpcr_flags |= __fpcr_trap_invalid;
+  }
+  if (fenv_flag & FE_FLUSHTOZERO ) {
+    fpcr_flags |= __fpcr_flush_to_zero;
+  }
+  // Better to assume nothing and be explicit...
+  if (fenv_flag == FE_ALL_EXCEPT ) {
+    // TODO: __fpcr_trap_inexact causes DrHook to SIGILL immediately
+    fpcr_flags |= __fpcr_trap_inexact & __fpcr_trap_underflow & __fpcr_trap_overflow &
+      __fpcr_trap_divbyzero & __fpcr_trap_invalid & __fpcr_flush_to_zero;
+  }
+  return fpcr_flags;
+}
+
+static unsigned int fpcr_to_fenv(unsigned long long fpcr_flags) {
+  unsigned int fenv_flag = 0;
+  if (fpcr_flags & __fpcr_trap_inexact) {
+    fenv_flag |= FE_INEXACT;
+  }
+  if (fpcr_flags & __fpcr_trap_underflow) {
+    fenv_flag |= FE_UNDERFLOW;
+  }
+  if (fpcr_flags & __fpcr_trap_overflow) {
+    fenv_flag |= FE_OVERFLOW;
+  }
+  if (fpcr_flags & __fpcr_trap_divbyzero) {
+    fenv_flag |= FE_DIVBYZERO;
+  }
+  if (fpcr_flags & __fpcr_trap_invalid) {
+    fenv_flag |= FE_INVALID;
+  }
+  if (fpcr_flags & __fpcr_flush_to_zero) {
+    fenv_flag |= FE_FLUSHTOZERO;
+  }
+  unsigned long long all_fpcr_flags = __fpcr_trap_inexact & __fpcr_trap_underflow &
+    __fpcr_trap_overflow & __fpcr_trap_divbyzero & __fpcr_trap_invalid & __fpcr_flush_to_zero;
+  if (fenv_flag == all_fpcr_flags ) {
+    return FE_ALL_EXCEPT;
+  }
+  return fenv_flag;
+}
+
+__attribute__((weak)) int feenableexcept (int excepts) {
+  fenv_t fenv;
+  unsigned int new_excepts = excepts & FE_ALL_EXCEPT;
+  unsigned int old_excepts; // previous masks
+
+  if (fegetenv(&fenv)) {
+    return -1;
+  }
+
+  old_excepts = fpcr_to_fenv(fenv.__fpcr) & FE_ALL_EXCEPT;
+
+  fenv.__fpcr |= fenv_to_fpcr(new_excepts);
+
+  return fesetenv(&fenv) ? -1 : old_excepts;
+}
+
+__attribute__((weak)) int fedisableexcept(int excepts) {
+  fenv_t fenv;
+  unsigned int new_excepts = excepts & FE_ALL_EXCEPT;
+  unsigned int old_excepts; // previous masks
+
+  if (fegetenv(&fenv)) {
+    return -1;
+  }
+
+  old_excepts = fpcr_to_fenv(fenv.__fpcr) & FE_ALL_EXCEPT;
+
+  fenv.__fpcr &= ~fenv_to_fpcr(new_excepts);
+
+  return fesetenv(&fenv) ? -1 : old_excepts;
+}
+__attribute__((weak)) int fegetexcept(void) {
+  fenv_t fenv;
+
+  if (fegetenv(&fenv)) {
+    return -1;
+  }
+
+  return fpcr_to_fenv(fenv.__fpcr) & FE_ALL_EXCEPT;
+}
+
+#elif defined(__APPLE__)
+// #if defined(__APPLE__)
   /*  A temporary fix to link on macOS. Something more clever will be done later -REK. */
 __attribute__((weak)) int feenableexcept (int excepts) { return -1; } // -1 assumes NO hardware support for FPE trapping
 __attribute__((weak)) int fedisableexcept(int excepts) { return -1; } // -1 assumes NO hardware support for FPE trapping
@@ -1487,6 +1588,8 @@ ignore_signals(int silent)
     trapfpe_treatment(x,0);                                                                                           \
   }
 
+#define TEST_ESR(sigcode) (uc->uc_mcontext->__es.__esr & 0x1 << sigcode)
+
 #define DRH_STRUCT_RLIMIT struct rlimit
 #define DRH_GETRLIMIT getrlimit
 #define DRH_SETRLIMIT setrlimit
@@ -1723,6 +1826,8 @@ signal_drhook(int sig SIG_EXTRA_ARGS)
         void *addr = sigcode->si_addr;
         void *bt = addr;
         ucontext_t *uc = (ucontext_t *)sigcontextptr;
+
+        int SIGFPE_via_SIGILL = 0;
 #ifdef __powerpc64__
         bt = uc ? (void *) uc->uc_mcontext.regs->nip : NULL;   // Trick from PAPI_overflow()
 #elif defined(__x86_64__) && defined(REG_RIP) // gcc specific
@@ -1746,18 +1851,64 @@ signal_drhook(int sig SIG_EXTRA_ARGS)
           }
         }
         else if (sig == SIGILL) {
-          switch (sigcode->si_code) {
-          case ILL_ILLOPC: s = "illegal opcode"; break;
-          case ILL_ILLOPN: s = "illegal operand"; break;
-          case ILL_ILLADR: s = "illegal addressing mode"; break;
-          case ILL_ILLTRP: s = "illegal trap"; break;
-          case ILL_PRVOPC: s = "privileged opcode"; break;
-          case ILL_PRVREG: s = "privileged register"; break;
-          case ILL_COPROC: s = "coprocessor error"; break;
-          case ILL_BADSTK: s = "internal stack error"; break;
-          default:
-            s = "unrecognized si_code for SIGILL";  break;
+#if defined(__APPLE__) && defined(__arm64__)
+          // On Apple Silicon a SIGFPE may be posing as a SIGILL
+          // See:
+          //    https://developer.apple.com/forums/thread/689159?answerId=733736022
+          //    https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/ESR-EL1--Exception-Syndrome-Register--EL1-?lang=en#fieldset_0-24_0_16-1_1
+          //    https://github.com/ecmwf/atlas/blob/develop/src/atlas/library/FloatingPointExceptions.cc
+          //
+
+          // Check the Trapped Fault Valid bit
+          int TFV_set = uc->uc_mcontext->__es.__esr & 0x1 << 23;
+          if (TFV_set) {
+            // Now know this is actually a SIGFPE, not a SIGILL
+            SIGFPE_via_SIGILL = 1;
+            if ( TEST_ESR(FPE_FLTDIV) ) {
+              s = "floating-point divide by zero";
+            }
+            else if ( TEST_ESR(FPE_FLTOVF) ) {
+              s = "floating-point overflow";
+            }
+            else if ( TEST_ESR(FPE_FLTUND) ) {
+              s = "floating-point underflow";
+            }
+            else if ( TEST_ESR(FPE_FLTRES) ) {
+              s = "floating-point inexact result";
+            }
+            else if ( TEST_ESR(FPE_FLTINV) ) {
+              s = "floating-point invalid operation";
+            }
+            else if ( TEST_ESR(FPE_FLTSUB) ) {
+              s = "subscript out of range";
+            }
+            else if ( TEST_ESR(FPE_INTDIV) ) {
+              s = "integer divide by zero";
+            }
+            else if ( TEST_ESR(FPE_INTOVF) ) {
+              s =  "integer overflow";
+            }
+            else {
+              s = "unrecognized si_code for SIGFPE";
+            }
+          } else {
+            // Else it's a true SIGILL
+#endif
+            switch (sigcode->si_code) {
+            case ILL_ILLOPC: s = "illegal opcode"; break;
+            case ILL_ILLOPN: s = "illegal operand"; break;
+            case ILL_ILLADR: s = "illegal addressing mode"; break;
+            case ILL_ILLTRP: s = "illegal trap"; break;
+            case ILL_PRVOPC: s = "privileged opcode"; break;
+            case ILL_PRVREG: s = "privileged register"; break;
+            case ILL_COPROC: s = "coprocessor error"; break;
+            case ILL_BADSTK: s = "internal stack error"; break;
+            default:
+              s = "unrecognized si_code for SIGILL";  break;
+            }
+#if defined(__APPLE__) && defined(__arm64__)
           }
+#endif
         }
         else if (sig == SIGSEGV) {
           switch (sigcode->si_code) {
@@ -1791,7 +1942,7 @@ signal_drhook(int sig SIG_EXTRA_ARGS)
           else
             dlworks = 1;
 
-          if (sig == SIGFPE) {
+          if (sig == SIGFPE || SIGFPE_via_SIGILL) {
             extern int fegetexcept(void);
             int excepts = fegetexcept();
             fprintf(stderr,

--- a/src/fiat/drhook/drhook.c
+++ b/src/fiat/drhook/drhook.c
@@ -307,8 +307,8 @@ __attribute__((weak)) int fegetexcept(void) {
   return fpcr_to_fenv(fenv.__fpcr) & FE_ALL_EXCEPT;
 }
 
-#elif defined(__APPLE__)
-// #if defined(__APPLE__)
+#elif defined(__APPLE__) && !defined(__arm64__)
+  /*  If we are dealing with an Intel Mac  */
   /*  A temporary fix to link on macOS. Something more clever will be done later -REK. */
 __attribute__((weak)) int feenableexcept (int excepts) { return -1; } // -1 assumes NO hardware support for FPE trapping
 __attribute__((weak)) int fedisableexcept(int excepts) { return -1; } // -1 assumes NO hardware support for FPE trapping
@@ -1588,8 +1588,6 @@ ignore_signals(int silent)
     trapfpe_treatment(x,0);                                                                                           \
   }
 
-#define TEST_ESR(sigcode) (uc->uc_mcontext->__es.__esr & 0x1 << sigcode)
-
 #define DRH_STRUCT_RLIMIT struct rlimit
 #define DRH_GETRLIMIT getrlimit
 #define DRH_SETRLIMIT setrlimit
@@ -1859,6 +1857,8 @@ signal_drhook(int sig SIG_EXTRA_ARGS)
           //    https://github.com/ecmwf/atlas/blob/develop/src/atlas/library/FloatingPointExceptions.cc
           //
 
+#define TEST_ESR(sigcode) (uc->uc_mcontext->__es.__esr & 0x1 << sigcode)
+
           // Check the Trapped Fault Valid bit
           int TFV_set = uc->uc_mcontext->__es.__esr & 0x1 << 23;
           if (TFV_set) {
@@ -1902,6 +1902,7 @@ signal_drhook(int sig SIG_EXTRA_ARGS)
             }
 #if defined(__APPLE__) && defined(__arm64__)
           }
+#undef TEST_ESR
 #endif
         }
         else if (sig == SIGSEGV) {

--- a/src/fiat/drhook/drhook.c
+++ b/src/fiat/drhook/drhook.c
@@ -296,6 +296,7 @@ __attribute__((weak)) int fedisableexcept(int excepts) {
 
   return fesetenv(&fenv) ? -1 : old_excepts;
 }
+
 __attribute__((weak)) int fegetexcept(void) {
   fenv_t fenv;
 
@@ -2628,6 +2629,10 @@ process_options()
     int prev_enabled_exceptions = fegetexcept();
     int drhook_trapfpe_hw_support = feenableexcept(FE_INVALID & FE_DIVBYZERO & FE_OVERFLOW) != -1;
     // Even if we failed above, we should still try to restore the flags
+#if defined(__APPLE__) && defined(__arm64__)
+    // This seems to be enabled by default, but causes DrHook to raise a SIGILL in the OPTPRINTs below
+    prev_enabled_exceptions &= ~FE_INEXACT;
+#endif
     feenableexcept(prev_enabled_exceptions);
     fedisableexcept(~prev_enabled_exceptions);
     if (!drhook_trapfpe_hw_support && drhook_trapfpe_sw == -1) {

--- a/src/fiat/drhook/drhook.c
+++ b/src/fiat/drhook/drhook.c
@@ -208,6 +208,7 @@ extern int fedisableexcept(int excepts);
 extern int fegetexcept(void);
 
 #if defined(__APPLE__) && defined(__arm64__)
+// If we are dealing with an Apple Silicon Mac
 // Borrowed from Atlas https://github.com/ecmwf/atlas/blob/develop/src/atlas/library/FloatingPointExceptions.cc
 static unsigned long long fenv_to_fpcr(unsigned int fenv_flag) {
   unsigned long long fpcr_flags = 0;

--- a/src/fiat/drhook/drhook.c
+++ b/src/fiat/drhook/drhook.c
@@ -1864,29 +1864,23 @@ signal_drhook(int sig SIG_EXTRA_ARGS)
           if (TFV_set) {
             // Now know this is actually a SIGFPE, not a SIGILL
             SIGFPE_via_SIGILL = 1;
-            if ( TEST_ESR(FPE_FLTDIV) ) {
-              s = "floating-point divide by zero";
-            }
-            else if ( TEST_ESR(FPE_FLTOVF) ) {
-              s = "floating-point overflow";
-            }
-            else if ( TEST_ESR(FPE_FLTUND) ) {
-              s = "floating-point underflow";
-            }
-            else if ( TEST_ESR(FPE_FLTRES) ) {
-              s = "floating-point inexact result";
-            }
-            else if ( TEST_ESR(FPE_FLTINV) ) {
+            if ( TEST_ESR(0) ) {
               s = "floating-point invalid operation";
             }
-            else if ( TEST_ESR(FPE_FLTSUB) ) {
-              s = "subscript out of range";
+            else if ( TEST_ESR(1) ) {
+              s = "floating-point divide by zero";
             }
-            else if ( TEST_ESR(FPE_INTDIV) ) {
-              s = "integer divide by zero";
+            else if ( TEST_ESR(2) ) {
+              s = "floating-point overflow";
             }
-            else if ( TEST_ESR(FPE_INTOVF) ) {
-              s =  "integer overflow";
+            else if ( TEST_ESR(3) ) {
+              s = "floating-point underflow";
+            }
+            else if ( TEST_ESR(4) ) {
+              s = "floating-point inexact result";
+            }
+            else if ( TEST_ESR(7) ) {
+              s = "floating-point denormal";
             }
             else {
               s = "unrecognized si_code for SIGFPE";

--- a/src/fiat/drhook/drhook.c
+++ b/src/fiat/drhook/drhook.c
@@ -231,7 +231,6 @@ static unsigned long long fenv_to_fpcr(unsigned int fenv_flag) {
   }
   // Better to assume nothing and be explicit...
   if (fenv_flag == FE_ALL_EXCEPT ) {
-    // TODO: __fpcr_trap_inexact causes DrHook to SIGILL immediately
     fpcr_flags |= __fpcr_trap_inexact & __fpcr_trap_underflow & __fpcr_trap_overflow &
       __fpcr_trap_divbyzero & __fpcr_trap_invalid & __fpcr_flush_to_zero;
   }
@@ -2627,7 +2626,7 @@ process_options()
     // Not all platforms, e.g. Nvidia's Grace, support trapping FPEs,
     // so we have to check if trapping is enabled
     int prev_enabled_exceptions = fegetexcept();
-    int drhook_trapfpe_hw_support = feenableexcept(FE_ALL_EXCEPT) != -1;
+    int drhook_trapfpe_hw_support = feenableexcept(FE_INVALID & FE_DIVBYZERO & FE_OVERFLOW) != -1;
     // Even if we failed above, we should still try to restore the flags
     feenableexcept(prev_enabled_exceptions);
     fedisableexcept(~prev_enabled_exceptions);

--- a/src/fiat/drhook/drhook.c
+++ b/src/fiat/drhook/drhook.c
@@ -231,8 +231,8 @@ static unsigned long long fenv_to_fpcr(unsigned int fenv_flag) {
   }
   // Better to assume nothing and be explicit...
   if (fenv_flag == FE_ALL_EXCEPT ) {
-    fpcr_flags |= __fpcr_trap_inexact & __fpcr_trap_underflow & __fpcr_trap_overflow &
-      __fpcr_trap_divbyzero & __fpcr_trap_invalid & __fpcr_flush_to_zero;
+    fpcr_flags |= __fpcr_trap_inexact | __fpcr_trap_underflow | __fpcr_trap_overflow |
+      __fpcr_trap_divbyzero | __fpcr_trap_invalid | __fpcr_flush_to_zero;
   }
   return fpcr_flags;
 }
@@ -257,8 +257,8 @@ static unsigned int fpcr_to_fenv(unsigned long long fpcr_flags) {
   if (fpcr_flags & __fpcr_flush_to_zero) {
     fenv_flag |= FE_FLUSHTOZERO;
   }
-  unsigned long long all_fpcr_flags = __fpcr_trap_inexact & __fpcr_trap_underflow &
-    __fpcr_trap_overflow & __fpcr_trap_divbyzero & __fpcr_trap_invalid & __fpcr_flush_to_zero;
+  unsigned long long all_fpcr_flags = __fpcr_trap_inexact | __fpcr_trap_underflow |
+    __fpcr_trap_overflow | __fpcr_trap_divbyzero | __fpcr_trap_invalid | __fpcr_flush_to_zero;
   if (fenv_flag == all_fpcr_flags ) {
     return FE_ALL_EXCEPT;
   }

--- a/src/fiat/drhook/drhook.c
+++ b/src/fiat/drhook/drhook.c
@@ -259,7 +259,7 @@ static unsigned int fpcr_to_fenv(unsigned long long fpcr_flags) {
   }
   unsigned long long all_fpcr_flags = __fpcr_trap_inexact | __fpcr_trap_underflow |
     __fpcr_trap_overflow | __fpcr_trap_divbyzero | __fpcr_trap_invalid | __fpcr_flush_to_zero;
-  if (fenv_flag == all_fpcr_flags ) {
+  if (fpcr_flags == all_fpcr_flags ) {
     return FE_ALL_EXCEPT;
   }
   return fenv_flag;
@@ -2621,7 +2621,7 @@ process_options()
     // Not all platforms, e.g. Nvidia's Grace, support trapping FPEs,
     // so we have to check if trapping is enabled
     int prev_enabled_exceptions = fegetexcept();
-    int drhook_trapfpe_hw_support = feenableexcept(FE_INVALID & FE_DIVBYZERO & FE_OVERFLOW) != -1;
+    int drhook_trapfpe_hw_support = feenableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW) != -1;
     // Even if we failed above, we should still try to restore the flags
 #if defined(__APPLE__) && defined(__arm64__)
     // This seems to be enabled by default, but causes DrHook to raise a SIGILL in the OPTPRINTs below

--- a/tests/drhook/drhook_core/drhook_no_hw_fpe/CMakeLists.txt
+++ b/tests/drhook/drhook_core/drhook_no_hw_fpe/CMakeLists.txt
@@ -88,3 +88,26 @@ set_tests_properties(${test_name}
     PROPERTIES ENVIRONMENT "DR_HOOK=1;DR_HOOK_TRAPFPE=1;DR_HOOK_SILENT=0;DR_HOOK_ASSERT_MPI_INITIALIZED=0" )
 
 ################################################################################
+# This test is to show that true SIGILL exceptions (i.e. not FPEs raised as SIGILLs) are still handled correctly on Apple Silicon.
+# This is because is raises FPEs as SIGILLs and not the SIGFPEs as would be expected on other platforms.
+if (APPLE AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
+
+ecbuild_add_executable( TARGET drhook_no_hw_fpe_Apple_Silicon_SIGILL
+    SOURCES drhook_no_hw_fpe_Apple_Silicon_SIGILL.F90 drhook_no_hw_fpe_fenv_util.c
+    LIBS ${fiatlib} ${CMATH_LIBRARIES}
+    LINKER_LANGUAGE Fortran
+    FFLAGS ${DRHOOK_HW_FPE_FFLAGS}
+    NOINSTALL )
+
+add_test(fiat_test_drhook_no_hw_fpe_Apple_Silicon_SIGILL
+    ${CMAKE_COMMAND}
+    "-DEXECUTABLE=${CMAKE_CURRENT_BINARY_DIR}/drhook_no_hw_fpe_Apple_Silicon_SIGILL"
+    "-DLAUNCH=${LAUNCH}"
+    "-DPASS_REGULAR_EXPRESSION='Program received signal SIGILL: Illegal instruction'"
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/../../../test_program_output.cmake)
+set_tests_properties(fiat_test_drhook_no_hw_fpe_Apple_Silicon_SIGILL
+    PROPERTIES ENVIRONMENT "DR_HOOK=1;DR_HOOK_TRAPFPE=1;DR_HOOK_SILENT=0;DR_HOOK_ASSERT_MPI_INITIALIZED=0" )
+
+endif ()
+
+################################################################################

--- a/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_check_hw_fpe_support.c
+++ b/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_check_hw_fpe_support.c
@@ -10,7 +10,84 @@
 
 #include <fenv.h>
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && defined(__arm64__)
+/*
+ * There is this implementation for Apple Silicon in DrHook.
+ * We can't link fiat to make this available because it
+ * won't have been built yet!
+ */
+static unsigned long long fenv_to_fpcr(unsigned int fenv_flag) {
+  unsigned long long fpcr_flags = 0;
+  if (fenv_flag & FE_INEXACT ) {
+    fpcr_flags |= __fpcr_trap_inexact;
+  }
+  if (fenv_flag & FE_UNDERFLOW ) {
+    fpcr_flags |= __fpcr_trap_underflow;
+  }
+  if (fenv_flag & FE_OVERFLOW ) {
+    fpcr_flags |= __fpcr_trap_overflow;
+  }
+  if (fenv_flag & FE_DIVBYZERO ) {
+    fpcr_flags |= __fpcr_trap_divbyzero;
+  }
+  if (fenv_flag & FE_INVALID ) {
+    fpcr_flags |= __fpcr_trap_invalid;
+  }
+  if (fenv_flag & FE_FLUSHTOZERO ) {
+    fpcr_flags |= __fpcr_flush_to_zero;
+  }
+  // Better to assume nothing and be explicit...
+  if (fenv_flag == FE_ALL_EXCEPT ) {
+    fpcr_flags |= __fpcr_trap_inexact & __fpcr_trap_underflow & __fpcr_trap_overflow &
+      __fpcr_trap_divbyzero & __fpcr_trap_invalid & __fpcr_flush_to_zero;
+  }
+  return fpcr_flags;
+}
+
+static unsigned int fpcr_to_fenv(unsigned long long fpcr_flags) {
+  unsigned int fenv_flag = 0;
+  if (fpcr_flags & __fpcr_trap_inexact) {
+    fenv_flag |= FE_INEXACT;
+  }
+  if (fpcr_flags & __fpcr_trap_underflow) {
+    fenv_flag |= FE_UNDERFLOW;
+  }
+  if (fpcr_flags & __fpcr_trap_overflow) {
+    fenv_flag |= FE_OVERFLOW;
+  }
+  if (fpcr_flags & __fpcr_trap_divbyzero) {
+    fenv_flag |= FE_DIVBYZERO;
+  }
+  if (fpcr_flags & __fpcr_trap_invalid) {
+    fenv_flag |= FE_INVALID;
+  }
+  if (fpcr_flags & __fpcr_flush_to_zero) {
+    fenv_flag |= FE_FLUSHTOZERO;
+  }
+  unsigned long long all_fpcr_flags = __fpcr_trap_inexact & __fpcr_trap_underflow &
+    __fpcr_trap_overflow & __fpcr_trap_divbyzero & __fpcr_trap_invalid & __fpcr_flush_to_zero;
+  if (fenv_flag == all_fpcr_flags ) {
+    return FE_ALL_EXCEPT;
+  }
+  return fenv_flag;
+}
+
+__attribute__((weak)) int feenableexcept (int excepts) {
+  fenv_t fenv;
+  unsigned int new_excepts = excepts & FE_ALL_EXCEPT;
+  unsigned int old_excepts; // previous masks
+
+  if (fegetenv(&fenv)) {
+    return -1;
+  }
+
+  old_excepts = fpcr_to_fenv(fenv.__fpcr) & FE_ALL_EXCEPT;
+
+  fenv.__fpcr |= fenv_to_fpcr(new_excepts);
+
+  return fesetenv(&fenv) ? -1 : old_excepts;
+}
+#elif defined(__APPLE__)
 /* Needed to pass compilation and pretend no hardware support */
 int feenableexcept(int mask) {
   return -1;
@@ -18,5 +95,5 @@ int feenableexcept(int mask) {
 #endif
 
 int main() {
-  return feenableexcept(FE_ALL_EXCEPT) == -1;
+  return feenableexcept(FE_INVALID & FE_DIVBYZERO & FE_OVERFLOW) == -1;
 }

--- a/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_check_hw_fpe_support.c
+++ b/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_check_hw_fpe_support.c
@@ -66,7 +66,7 @@ static unsigned int fpcr_to_fenv(unsigned long long fpcr_flags) {
   }
   unsigned long long all_fpcr_flags = __fpcr_trap_inexact & __fpcr_trap_underflow &
     __fpcr_trap_overflow & __fpcr_trap_divbyzero & __fpcr_trap_invalid & __fpcr_flush_to_zero;
-  if (fenv_flag == all_fpcr_flags ) {
+  if (fpcr_flags == all_fpcr_flags ) {
     return FE_ALL_EXCEPT;
   }
   return fenv_flag;
@@ -95,5 +95,5 @@ int feenableexcept(int mask) {
 #endif
 
 int main() {
-  return feenableexcept(FE_INVALID & FE_DIVBYZERO & FE_OVERFLOW) == -1;
+  return feenableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW) == -1;
 }

--- a/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_no_hw_fpe_Apple_Silicon_SIGILL.f90
+++ b/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_no_hw_fpe_Apple_Silicon_SIGILL.f90
@@ -22,6 +22,9 @@ program drhook_no_hw_fpe_Apple_Silicon_SIGILL
 
   call dr_hook('drhook_no_hw_fpe_Apple_Silicon_SIGILL', 0, zhook_handle)
 
+  ! Ensure that DrHook still processes legitamate SIGILLs, as signal_drhook()
+  ! converts SIGFPEs posing as SIGILLs to SIGFPEs.
+  ! https://developer.apple.com/forums/thread/689159?answerId=733736022
   call raise_sigill()
 
   call dr_hook('drhook_no_hw_fpe_Apple_Silicon_SIGILL', 1, zhook_handle)

--- a/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_no_hw_fpe_Apple_Silicon_SIGILL.f90
+++ b/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_no_hw_fpe_Apple_Silicon_SIGILL.f90
@@ -1,0 +1,30 @@
+! (C) Copyright 2026- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+!
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
+program drhook_no_hw_fpe_Apple_Silicon_SIGILL
+
+  use yomhook, only : jphook, dr_hook
+
+  implicit none
+
+  real(jphook) :: zhook_handle
+
+  interface
+    subroutine raise_sigill() bind(C, name="raise_sigill")
+    end subroutine
+  end interface
+
+  call dr_hook('drhook_no_hw_fpe_Apple_Silicon_SIGILL', 0, zhook_handle)
+
+  call raise_sigill()
+
+  call dr_hook('drhook_no_hw_fpe_Apple_Silicon_SIGILL', 1, zhook_handle)
+
+end program drhook_no_hw_fpe_Apple_Silicon_SIGILL
+

--- a/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_no_hw_fpe_basic.F90
+++ b/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_no_hw_fpe_basic.F90
@@ -13,7 +13,7 @@ use yomhook, only : jphook, dr_hook
 
 implicit none
 
-real(jphook) :: zhook_handle, zhook_handle_a
+real(jphook) :: zhook_handle
 real :: x
 real, volatile :: y ! This is needed because some compilers are smart enough to perform constant folding at compile time, which prevents FPE flags being set a runtime
 

--- a/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_no_hw_fpe_fenv_util.c
+++ b/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_no_hw_fpe_fenv_util.c
@@ -9,11 +9,18 @@
  */
 
 #include <fenv.h>
+#include <signal.h>
 
 void silently_disable_all_fpes() {
   fenv_t envp;
   feholdexcept(&envp);
 }
+
+#if defined(__APPLE__) && defined(__arm64__)
+void raise_sigill() {
+  raise(SIGILL);
+}
+#endif
 
 #ifdef MOCK_HARDWARE_FPE_SUPPORT
 

--- a/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_no_hw_fpe_fenv_util.c
+++ b/tests/drhook/drhook_core/drhook_no_hw_fpe/drhook_no_hw_fpe_fenv_util.c
@@ -16,11 +16,9 @@ void silently_disable_all_fpes() {
   feholdexcept(&envp);
 }
 
-#if defined(__APPLE__) && defined(__arm64__)
 void raise_sigill() {
   raise(SIGILL);
 }
-#endif
 
 #ifdef MOCK_HARDWARE_FPE_SUPPORT
 


### PR DESCRIPTION
### Description
This PR is inspired by work done in Atlas[\[1\]](https://github.com/ecmwf/atlas/blob/e0af59ef4d895ffc647a9db01b48c0a3e13d16f6/src/atlas/library/FloatingPointExceptions.cc#L57)[\[2\]](https://github.com/ecmwf/atlas/blob/e0af59ef4d895ffc647a9db01b48c0a3e13d16f6/src/atlas/library/FloatingPointExceptions.cc#L203). It uses the floating point control register (FPCR) and floating point status register (FPSR) to trap requested FPEs using hardware trapping. These are natively treated as SIGILL exceptions, so DrHook will now reinterpret them as SIGFPEs to maintain consistency with other platforms.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 