### PR TITLE
Add `JPLM` to `EC_PARKIND`

### DIFF
--- a/src/fiat/util/ec_parkind.F90
+++ b/src/fiat/util/ec_parkind.F90
@@ -20,6 +20,8 @@ SAVE
 !     Integer Kinds
 !     -------------
 !
+! NOTE: If any symbols herein are updated, please also update the 
+!       corresponding symbols in PARKIND1
 INTEGER, PARAMETER :: JPIM = SELECTED_INT_KIND(9)
 INTEGER, PARAMETER :: JPIB = SELECTED_INT_KIND(12)
 INTEGER, PARAMETER :: JPIA = C_INTPTR_T
@@ -31,5 +33,6 @@ INTEGER, PARAMETER :: JPIA = C_INTPTR_T
 INTEGER, PARAMETER :: JPRM = SELECTED_REAL_KIND(6,37)
 INTEGER, PARAMETER :: JPRD = SELECTED_REAL_KIND(13,300)
 
+INTEGER, PARAMETER :: JPLM = JPIM   !Standard logical type
 
 END MODULE EC_PARKIND

--- a/src/parkind/parkind1.F90
+++ b/src/parkind/parkind1.F90
@@ -16,6 +16,10 @@ USE, INTRINSIC :: ISO_C_BINDING, ONLY : C_INTPTR_T
 IMPLICIT NONE
 PRIVATE :: C_INTPTR_T
 SAVE
+
+! NOTE: If JPIM, JPIB, JPIA, JPRM, JPRD or JPLM are updated
+!       please also update the corresponding symbols in EC_PARKIND
+
 !
 !     Integer Kinds
 !     -------------


### PR DESCRIPTION
A small PR to add `JPLM` to `EC_PARKIND`, along with a comment clarifying that the duplicated symbols in `EC_PARKIND` and `PARKIND1` should always remain in sync.