### PR TITLE
Only run fiat_test_install with MPI

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -377,8 +377,10 @@ foreach( lang C CXX Fortran )
   endif()
 endforeach()
 
-add_test( NAME fiat_test_install
-          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-install.sh ${_test_args} )
+if(HAVE_MPI)
+  add_test( NAME fiat_test_install
+            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-install.sh ${_test_args} )
+endif()
 
 # ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Description

Only run fiat_test_install with MPI has been found.  Fix #125.;

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 